### PR TITLE
Don't link librt on osx

### DIFF
--- a/configure.self
+++ b/configure.self
@@ -25,6 +25,9 @@ function checks {
     # Older g++ (<=4.1?) gives invalid warnings for the C++ code.
     mkl_mkvar_append CXXFLAGS CXXFLAGS "-Wno-non-virtual-dtor"
 
+    # -lrt is needed on linux for clock_gettime: link it if it exists.
+    mkl_lib_check "librt" "" cont CC "-lrt"
+
     # Required on SunOS
     if [[ $MKL_DISTRO == "SunOS" ]]; then
 	mkl_mkvar_append CPPFLAGS CPPFLAGS "-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D__EXTENSIONS__"

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -23,7 +23,7 @@ CPPFLAGS := $(subst strict-dwarf,,$(CPPFLAGS))
 
 serdes-kafka-avro-client: $(SLIB) serdes-kafka-avro-client.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) serdes-kafka-avro-client.c \
-	-o $@ $(LDFLAGS) $(SLIB) $(LIBS) -lrdkafka -lrt
+	-o $@ $(LDFLAGS) $(SLIB) $(LIBS) -lrdkafka
 
 serdes-tool: $(SLIB) $(SLIB_CPP) serdes-tool.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ \
@@ -32,11 +32,11 @@ serdes-tool: $(SLIB) $(SLIB_CPP) serdes-tool.cpp
 
 kafka-serdes-avro-console-consumer: $(SLIB) $(SLIB_CPP) kafka-serdes-avro-console-consumer.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ \
-	-o $@ $(LDFLAGS) $(SLIB_CPP) $(SLIB) $(LIBS) -lrdkafka++ -lrdkafka -lrt
+	-o $@ $(LDFLAGS) $(SLIB_CPP) $(SLIB) $(LIBS) -lrdkafka++ -lrdkafka
 
 kafka-serdes-avro-console-producer: $(SLIB) $(SLIB_CPP) kafka-serdes-avro-console-producer.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ \
-	-o $@ $(LDFLAGS) $(SLIB_CPP) $(SLIB) $(LIBS) -lrdkafka++ -lrdkafka -lrt
+	-o $@ $(LDFLAGS) $(SLIB_CPP) $(SLIB) $(LIBS) -lrdkafka++ -lrdkafka
 
 
 clean:


### PR DESCRIPTION
`-lrt` doesn't exist on osx, so don't try and link against it. This is a straight copy of what librdkafka does.