### PR TITLE
Implement serdes_schema_avro

### DIFF
--- a/src/schema-avro.c
+++ b/src/schema-avro.c
@@ -39,3 +39,7 @@ void serdes_avro_schema_unload_cb (serdes_schema_t *ss, void *schema_obj,
 
         avro_schema_decref(avro_schema);
 }
+
+const avro_schema_t serdes_schema_avro (serdes_schema_t *ss) {
+    return ss->ss_schema_obj;
+}

--- a/src/schema-avro.c
+++ b/src/schema-avro.c
@@ -41,5 +41,5 @@ void serdes_avro_schema_unload_cb (serdes_schema_t *ss, void *schema_obj,
 }
 
 const avro_schema_t serdes_schema_avro (serdes_schema_t *ss) {
-    return ss->ss_schema_obj;
+        return ss->ss_schema_obj;
 }


### PR DESCRIPTION
It's defined in serdes-avro.h but not implemented.

Had a look if it's possible/would make sense to do some checks before casting, but couldn't find anything.