### PR TITLE
fix parse schema registry urls

### DIFF
--- a/src/rest.c
+++ b/src/rest.c
@@ -51,7 +51,8 @@ int url_list_parse (url_list_t *ul, const char *urls) {
         ul->max_len = 0;
         ul->urls    = NULL;
 
-        s = ul->str;
+        s = strdup(ul->str);
+        ul->parsed_url = s;
 
         while (*s) {
                 int len;
@@ -59,8 +60,10 @@ int url_list_parse (url_list_t *ul, const char *urls) {
                 while (*s == ' ')
                         s++;
 
-                if ((t = strchr(s, ',')))
+                if ((t = strchr(s, ','))) {
                         *t = '\0';
+                        t++;
+                }
                 else
                         t = s + strlen(s);
 
@@ -77,10 +80,13 @@ int url_list_parse (url_list_t *ul, const char *urls) {
 }
 
 void url_list_clear (url_list_t *ul) {
+
         if (ul->urls)
                 free(ul->urls);
         if (ul->str)
                 free(ul->str);
+        if (ul->parsed_url)
+                free(ul->parsed_url);
 }
 
 

--- a/src/rest.h
+++ b/src/rest.h
@@ -34,6 +34,7 @@ typedef struct url_list_s {
         int    idx;           /* Next URL to try */
         char  *str;           /* Original string (copy), urls[..] points here */
         int    max_len;       /* Longest URL's length */
+        char  *parsed_url;    /* Replace comma in str with "\0" */
 } url_list_t;
 
 


### PR DESCRIPTION
Schema url is "localhost:8080,localhost:8081", localhost:8080 is
not a invalid url, localhost:8081 is a valid url.
serdes-kafka-avro-client consumes data failed using above url.

Function url_list_parse replaces the comma in ul->str(the raw
 schema url) with "\0" and serdes_conf_copy0 just get the
first schema url.