### PR TITLE
Fixed HandleImpl inheritance

### DIFF
--- a/src-cpp/serdescpp_int.h
+++ b/src-cpp/serdescpp_int.h
@@ -70,7 +70,7 @@ namespace Serdes {
   };
 
 
-  class HandleImpl : public Handle {
+  class HandleImpl : public virtual Handle {
  public:
     ~HandleImpl () {
       if (sd_)
@@ -159,7 +159,7 @@ namespace Serdes {
   };
 
 
-  class AvroImpl : virtual public Avro, virtual public HandleImpl {
+  class AvroImpl : public Avro, public HandleImpl {
  public:
     ~AvroImpl () { }
 
@@ -172,15 +172,15 @@ namespace Serdes {
                          const void *payload, size_t size, std::string &errstr);
 
     ssize_t serializer_framing_size () const {
-      return dynamic_cast<const HandleImpl*>(this)->serializer_framing_size();
+      return HandleImpl::serializer_framing_size();
     }
 
     ssize_t deserializer_framing_size () const {
-      return dynamic_cast<const HandleImpl*>(this)->deserializer_framing_size();
+      return HandleImpl::deserializer_framing_size();
     }
 
     int schemas_purge (int max_age) {
-      return dynamic_cast<HandleImpl*>(this)->schemas_purge(max_age);
+      return HandleImpl::schemas_purge(max_age);
     }
 
   };


### PR DESCRIPTION
I found that calling `serializer_framing_size()` was resulting in an infinite loop in my compilation environment (clang 8, macOS). I assume this because implementation details for the virtual inheritance meant that the same method was being called again, rather than the base class version. However, I believe that the manual `dynamic_cast` was only necessary in the first place because the virtual inheritance configuration was incorrect (as described [here](https://isocpp.org/wiki/faq/multiple-inheritance#virtual-inheritance-where), for example). That is, the virtual inheritance was at (2) below, whereas it should be at (1).

```
       Handle
      /      \               (1)
  Avro        HandleImpl
      \      /               (2)
        Avro
```