### PR TITLE
Fixed compatibility with Avro master branch

### DIFF
--- a/examples/kafka-serdes-avro-console-consumer.cpp
+++ b/examples/kafka-serdes-avro-console-consumer.cpp
@@ -71,7 +71,7 @@ static int avro2json (Serdes::Schema *schema, const avro::GenericDatum *datum,
 
   /* JSON output stream */
   std::ostringstream oss;
-  std::auto_ptr<avro::OutputStream> json_os = avro::ostreamOutputStream(oss);
+  auto json_os = avro::ostreamOutputStream(oss);
 
   try {
     /* Encode Avro datum to JSON */

--- a/examples/kafka-serdes-avro-console-producer.cpp
+++ b/examples/kafka-serdes-avro-console-producer.cpp
@@ -85,7 +85,7 @@ static int json2avro (Serdes::Schema *schema, const std::string &json,
 
   /* Input stream from json string */
   std::istringstream iss(json);
-  std::auto_ptr<avro::InputStream> json_is = avro::istreamInputStream(iss);
+  auto json_is = avro::istreamInputStream(iss);
 
   /* JSON decoder */
   avro::DecoderPtr json_decoder = avro::jsonDecoder(*avro_schema);

--- a/examples/serdes-tool.cpp
+++ b/examples/serdes-tool.cpp
@@ -84,8 +84,7 @@ static void decode_json (Serdes::Schema *schema, const std::string &json_str) {
 
   decoder = avro::jsonDecoder(*static_cast<avro::ValidSchema*>(schema->object()));
 
-  std::auto_ptr<avro::InputStream> istream =
-      avro::memoryInputStream((const uint8_t *)json_str.c_str(), json_str.size());
+  auto istream = avro::memoryInputStream((const uint8_t *)json_str.c_str(), json_str.size());
 
   decoder->init(*istream);
   try {

--- a/src-cpp/Serdes.cpp
+++ b/src-cpp/Serdes.cpp
@@ -218,13 +218,12 @@ Avro *Avro::create (const Conf *conf, std::string &errstr) {
 
 ssize_t AvroImpl::serialize (Schema *schema, const avro::GenericDatum *datum,
                              std::vector<char> &out, std::string &errstr) {
-  avro::ValidSchema *avro_schema = schema->object();
+  auto avro_schema = schema->object();
 
   /* Binary encoded output stream */
-  std::auto_ptr<avro::OutputStream> bin_os = avro::memoryOutputStream();
+  auto bin_os = avro::memoryOutputStream();
   /* Avro binary encoder */
-  avro::EncoderPtr bin_encoder = avro::validatingEncoder(*avro_schema,
-                                                         avro::binaryEncoder());
+  auto bin_encoder = avro::validatingEncoder(*avro_schema, avro::binaryEncoder());
 
   try {
     /* Encode Avro datum to Avro binary format */
@@ -238,19 +237,16 @@ ssize_t AvroImpl::serialize (Schema *schema, const avro::GenericDatum *datum,
   }
 
   /* Extract written bytes. */
-  boost::shared_ptr<std::vector<uint8_t> > v;
-  v = avro::snapshot(*bin_os.get());
+  auto encoded = avro::snapshot(*bin_os.get());
 
   /* Write framing */
   schema->framing_write(out);
 
   /* Write binary encoded Avro to output vector */
-  out.insert(out.end(), v->begin(), v->end());
-
+  out.insert(out.end(), encoded->cbegin(), encoded->cend());
 
   return out.size();
 }
-
 
 
 ssize_t AvroImpl::deserialize (Schema **schemap, avro::GenericDatum **datump,
@@ -281,8 +277,7 @@ ssize_t AvroImpl::deserialize (Schema **schemap, avro::GenericDatum **datump,
   avro::ValidSchema *avro_schema = schema->object();
 
   /* Binary input stream */
-  std::auto_ptr<avro::InputStream> bin_is =
-      avro::memoryInputStream((const uint8_t *)payload, size);
+  auto bin_is = avro::memoryInputStream((const uint8_t *)payload, size);
 
   /* Binary Avro decoder */
   avro::DecoderPtr bin_decoder = avro::validatingDecoder(*avro_schema,


### PR DESCRIPTION
... while retaining backwards compatibility with released versions. However, the trade-off is that C++11 is now required.

(An alternative would be to switch to explicitly saying `shared_ptr` instead of `auto_ptr`, but C++11 seems like a reasonable requirement to impose, given that the underlying Avro library has already done so.)