### PR TITLE
Feature/add support for topic name strategy

### DIFF
--- a/src-cpp/Serdes.cpp
+++ b/src-cpp/Serdes.cpp
@@ -198,8 +198,6 @@ Schema *Schema::add (Handle *handle, const std::string &name, int id,
                     definition.c_str(), definition.length(), errstr);
 }
 
-
-
 Serdes::Avro::~Avro () {
 
 }


### PR DESCRIPTION
In order to add support for topic name strategy (being the default for SchemaRegistry in Java), 
libserdes needs to allow registering the same schema under different names. 
The change checks for the name in the cache first. If absent, it is allowed to be registered/cached.
If name is not provided defaults to the existing behavior.