### PR TITLE
Fix ubuntu package name: libcurl-gnutls-dev → libcurl4-gnutls-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ serialization type.
 
 
 On Debian/Ubuntu based systems:
-`sudo apt-get install libjansson-dev libcurl-gnutls-dev`
+`sudo apt-get install libjansson-dev libcurl4-gnutls-dev`
 
  **NOTE: The avro libraries needs to be installed manually or through [Confluent's APT and YUM repositories](http://docs.confluent.io/current/installation.html)**
 


### PR DESCRIPTION
I found this glitch while I was building [kafkacat](https://github.com/edenhill/kafkacat).

As you can see below, there are no `libcurl-gnutls-dev` package in ubuntu anymore - `libcurl4-gnutls-dev` is used instead.

- [search by `libcurl-gnutls-dev`](https://packages.ubuntu.com/search?keywords=libcurl-gnutls-dev)
- [search by `libcurl4-gnutls-dev`](https://packages.ubuntu.com/search?keywords=libcurl4-gnutls-dev)