### PR TITLE
El8 support

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -7,7 +7,7 @@ MOCK_CONFIG?=default
 
 RESULT_DIR?=pkgs-$(VERSION)-$(BUILD_NUMBER)-$(MOCK_CONFIG)
 
-BUILD_DEPENDS?= avro-c avro-c-devel librdkafka
+BUILD_DEPENDS?= avro-c avro-cpp librdkafka
 
 all: rpm
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -7,7 +7,7 @@ MOCK_CONFIG?=default
 
 RESULT_DIR?=pkgs-$(VERSION)-$(BUILD_NUMBER)-$(MOCK_CONFIG)
 
-BUILD_DEPENDS?= avro-c avro-c-devel
+BUILD_DEPENDS?= avro-c avro-c-devel librdkafka
 
 all: rpm
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -30,18 +30,20 @@ build_prepare: archive
 # such as avro-c.
 install-deps:
 	@([ -d "$(REPO_DIR)" ] || (echo "REPO_DIR must be set to a path containing $(BUILD_DEPENDS) RPMs" ; exit 1))
-	[ -f $(RESULT_DIR)/state.log ] || /usr/bin/mock -r $(MOCK_CONFIG) \
+	[ -f $(RESULT_DIR)/state.log ] || /usr/bin/mock -r $(MOCK_CONFIG) $(MOCK_OPTIONS) \
 		--resultdir=$(RESULT_DIR) --init
-	$(eval DEP_PKGS := $(shell (for d in $(BUILD_DEPENDS) ; do ls $(REPO_DIR)/$${d}*.rpm | grep -v -E '(debuginfo|\.src\.rpm)' ; done)))
+	$(eval DEP_PKGS := $(shell (for d in $(BUILD_DEPENDS) ; do ls $(REPO_DIR)/$${d}*.rpm | grep -v -E '(debuginfo|debugsource|\.src\.rpm)' ; done | sort -u)))
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		-r $(MOCK_CONFIG) \
 		--no-clean \
 		--no-cleanup-after \
 		--resultdir=$(RESULT_DIR) \
-		--install $(DEP_PKGS) || true
+		--install $(DEP_PKGS)
 
 srpm: build_prepare
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		-r $(MOCK_CONFIG) \
 		--no-clean \
 		--no-cleanup-after \
@@ -55,6 +57,7 @@ srpm: build_prepare
 
 rpm: srpm
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		-r $(MOCK_CONFIG) \
 		--no-clean \
 		--no-cleanup-after \

--- a/rpm/confluent-libserdes.spec
+++ b/rpm/confluent-libserdes.spec
@@ -8,7 +8,7 @@ License: ASL 2.0
 URL:     https://github.com/confluentinc/libserdes
 Source:	 confluent-libserdes-%{version}.tar.gz
 
-BuildRequires: libcurl-devel jansson-devel avro-c-devel avro-cpp-devel perl
+BuildRequires: libcurl-devel jansson-devel avro-c-devel avro-cpp-devel perl librdkafka-devel
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %description

--- a/rpm/confluent-libserdes.spec
+++ b/rpm/confluent-libserdes.spec
@@ -8,7 +8,7 @@ License: ASL 2.0
 URL:     https://github.com/confluentinc/libserdes
 Source:	 confluent-libserdes-%{version}.tar.gz
 
-BuildRequires: libcurl-devel jansson-devel avro-c-devel avro-cpp-devel
+BuildRequires: libcurl-devel jansson-devel avro-c-devel avro-cpp-devel perl
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %description


### PR DESCRIPTION
These changes are required for building on EL8:

* `$(MOCK_OPTIONS)` override (Similar to what I've been doing with the other C-packages)
* Theres a bug in install-deps where it would list the same `avro-c-devel` package twice on the install which causes an issue with mock. So we `sort -u` to remove duplicates if it happens.
* `BUILD_DEPENDS` should really include both `avro-c` and `avro-cpp`
* Build also requires librdkafka, hence why I'm adding it to `BUILD_DEPENDS` (also in the Spec file)
* EL8's basic environment no longer includes perl now, so we have to declare it as a BuildDependency in the spec file.

This PR is dependent on https://github.com/confluentinc/avro-c-packaging/pull/6

### Testing

#### EL8

```
[root@ip-172-31-35-84 rpm]# ls $REPO_DIR/
avro-c-1.8.0-1.el8.src.rpm                 avro-cpp-1.8.0-1.el8.x86_64.rpm                  avro-c-tools-debuginfo-1.8.0-1.el8.x86_64.rpm
avro-c-1.8.0-1.el8.x86_64.rpm              avro-cpp-debuginfo-1.8.0-1.el8.x86_64.rpm        librdkafka1-1.4.2-1.el8.x86_64.rpm
avro-c-debuginfo-1.8.0-1.el8.x86_64.rpm    avro-cpp-debugsource-1.8.0-1.el8.x86_64.rpm      librdkafka-1.4.2-1.el8.src.rpm
avro-c-debugsource-1.8.0-1.el8.x86_64.rpm  avro-cpp-devel-1.8.0-1.el8.x86_64.rpm            librdkafka1-debuginfo-1.4.2-1.el8.x86_64.rpm
avro-c-devel-1.8.0-1.el8.x86_64.rpm        avro-cpp-devel-debuginfo-1.8.0-1.el8.x86_64.rpm  librdkafka-debugsource-1.4.2-1.el8.x86_64.rpm
avro-cpp-1.8.0-1.el8.src.rpm               avro-c-tools-1.8.0-1.el8.x86_64.rpm              librdkafka-devel-1.4.2-1.el8.x86_64.rpm
[root@ip-172-31-35-84 rpm]# make MOCK_CONFIG=epel-8-x86_64 MOCK_OPTIONS=--bootstrap-chroot install-deps all
[root@ip-172-31-35-84 rpm]# make MOCK_CONFIG=epel-8-x86_64 MOCK_OPTIONS=--bootstrap-chroot install-deps all
[ -f pkgs-1.0.0-1-epel-8-x86_64/state.log ] || /usr/bin/mock -r epel-8-x86_64 --bootstrap-chroot \
	--resultdir=pkgs-1.0.0-1-epel-8-x86_64 --init
/usr/bin/mock \
	--bootstrap-chroot \
	-r epel-8-x86_64 \
	--no-clean \
	--no-cleanup-after \
	--resultdir=pkgs-1.0.0-1-epel-8-x86_64 \
	--install /tmp/_libserdes-deps/avro-c-1.8.0-1.el8.x86_64.rpm /tmp/_libserdes-deps/avro-c-devel-1.8.0-1.el8.x86_64.rpm /tmp/_libserdes-deps/avro-cpp-1.8.0-1.el8.x86_64.rpm /tmp/_libserdes-deps/avro-cpp-devel-1.8.0-1.el8.x86_64.rpm /tmp/_libserdes-deps/avro-c-tools-1.8.0-1.el8.x86_64.rpm /tmp/_libserdes-deps/librdkafka1-1.4.2-1.el8.x86_64.rpm /tmp/_libserdes-deps/librdkafka-devel-1.4.2-1.el8.x86_64.rpm
INFO: mock.py version 1.4.21 starting (python version = 3.6.8)...
...
Dependencies resolved.
===========================================================================================================================================================
 Package                                      Architecture                  Version                              Repository                           Size
===========================================================================================================================================================
Installing:
 avro-c                                       x86_64                        1.8.0-1.el8                          @commandline                         89 k
 avro-c-devel                                 x86_64                        1.8.0-1.el8                          @commandline                        142 k
 avro-cpp                                     x86_64                        1.8.0-1.el8                          @commandline                        431 k
 avro-cpp-devel                               x86_64                        1.8.0-1.el8                          @commandline                        1.4 M
 avro-c-tools                                 x86_64                        1.8.0-1.el8                          @commandline                        150 k
 librdkafka1                                  x86_64                        1.4.2-1.el8                          @commandline                        973 k
 librdkafka-devel                             x86_64                        1.4.2-1.el8                          @commandline                        1.1 M
...
Provides: confluent-libserdes-devel = 1.0.0-1.el8 confluent-libserdes-devel(x86-64) = 1.0.0-1.el8
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: libserdes++.so.1()(64bit) libserdes.so.1()(64bit)
Processing files: confluent-libserdes-debugsource-1.0.0-1.el8.x86_64
Provides: confluent-libserdes-debugsource = 1.0.0-1.el8 confluent-libserdes-debugsource(x86-64) = 1.0.0-1.el8
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Processing files: confluent-libserdes-debuginfo-1.0.0-1.el8.x86_64
Provides: confluent-libserdes-debuginfo = 1.0.0-1.el8 confluent-libserdes-debuginfo(x86-64) = 1.0.0-1.el8 debuginfo(build-id) = 397204343bd3b2ac94f53c3e45b5e0f4cd28eec3 debuginfo(build-id) = 445b953538714e1d595c591042714aed2b0b10b0
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Recommends: confluent-libserdes-debugsource(x86-64) = 1.0.0-1.el8
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/confluent-libserdes-1.0.0-1.el8.x86_64
Wrote: /builddir/build/RPMS/confluent-libserdes-1.0.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/confluent-libserdes-devel-1.0.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/confluent-libserdes-debugsource-1.0.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/confluent-libserdes-debuginfo-1.0.0-1.el8.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.lGBNuV
+ umask 022
+ cd /builddir/build/BUILD
+ cd confluent-libserdes-1.0.0
+ rm -rf /builddir/build/BUILDROOT/confluent-libserdes-1.0.0-1.el8.x86_64
+ exit 0
Finish: rpmbuild confluent-libserdes-1.0.0-1.el8.src.rpm
Finish: build phase for confluent-libserdes-1.0.0-1.el8.src.rpm
INFO: Done(pkgs-1.0.0-1-epel-8-x86_64/confluent-libserdes-1.0.0-1.el8.src.rpm) Config(epel-8-x86_64) 0 minutes 29 seconds
INFO: Results and/or logs in: pkgs-1.0.0-1-epel-8-x86_64
Finish: run
======= Binary RPMs now available in pkgs-1.0.0-1-epel-8-x86_64 =======
```

#### EL7

```
[root@ip-172-31-35-84 rpm]# ls $REPO_DIR/
avro-c-1.8.0-1.el7.src.rpm               avro-cpp-1.8.0-1.el7.x86_64.rpm            librdkafka-1.4.2-1.el7.src.rpm
avro-c-1.8.0-1.el7.x86_64.rpm            avro-cpp-debuginfo-1.8.0-1.el7.x86_64.rpm  librdkafka-debuginfo-1.4.2-1.el7.x86_64.rpm
avro-c-debuginfo-1.8.0-1.el7.x86_64.rpm  avro-cpp-devel-1.8.0-1.el7.x86_64.rpm      librdkafka-devel-1.4.2-1.el7.x86_64.rpm
avro-c-devel-1.8.0-1.el7.x86_64.rpm      avro-c-tools-1.8.0-1.el7.x86_64.rpm
avro-cpp-1.8.0-1.el7.src.rpm             librdkafka1-1.4.2-1.el7.x86_64.rpm
[root@ip-172-31-35-84 rpm]# pwd
/tmp/libserdes/rpm
[root@ip-172-31-35-84 rpm]# make MOCK_CONFIG=epel-7-x86_64 install-deps all
[ -f pkgs-1.0.0-1-epel-7-x86_64/state.log ] || /usr/bin/mock -r epel-7-x86_64  \
	--resultdir=pkgs-1.0.0-1-epel-7-x86_64 --init
INFO: mock.py version 1.4.21 starting (python version = 3.6.8)...
Start: init plugins
INFO: selinux enabled
Finish: init plugins
INFO: Signal handler active
Start: run
Start: clean chroot
Finish: clean chroot
Start: chroot init
INFO: calling preinit hooks
INFO: enabled root cache
Start: unpacking root cache
Finish: unpacking root cache
INFO: enabled yum cache
Start: cleaning yum metadata
Finish: cleaning yum metadata
INFO: enabled HW Info plugin
Mock Version: 1.4.21
INFO: Mock Version: 1.4.21
Finish: chroot init
Finish: run
/usr/bin/mock \
	 \
	-r epel-7-x86_64 \
	--no-clean \
	--no-cleanup-after \
	--resultdir=pkgs-1.0.0-1-epel-7-x86_64 \
	--install /tmp/_libserdes-deps/avro-c-1.8.0-1.el7.x86_64.rpm /tmp/_libserdes-deps/avro-c-devel-1.8.0-1.el7.x86_64.rpm /tmp/_libserdes-deps/avro-cpp-1.8.0-1.el7.x86_64.rpm /tmp/_libserdes-deps/avro-cpp-devel-1.8.0-1.el7.x86_64.rpm /tmp/_libserdes-deps/avro-c-tools-1.8.0-1.el7.x86_64.rpm /tmp/_libserdes-deps/librdkafka1-1.4.2-1.el7.x86_64.rpm /tmp/_libserdes-deps/librdkafka-devel-1.4.2-1.el7.x86_64.rpm
...
Wrote: /builddir/build/RPMS/confluent-libserdes-1.0.0-1.el7.x86_64.rpm
Wrote: /builddir/build/RPMS/confluent-libserdes-devel-1.0.0-1.el7.x86_64.rpm
Wrote: /builddir/build/RPMS/confluent-libserdes-debuginfo-1.0.0-1.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.ThhkJI
+ umask 022
+ cd /builddir/build/BUILD
+ cd confluent-libserdes-1.0.0
+ rm -rf /builddir/build/BUILDROOT/confluent-libserdes-1.0.0-1.el7.x86_64
+ exit 0
Finish: rpmbuild confluent-libserdes-1.0.0-1.el7.src.rpm
Finish: build phase for confluent-libserdes-1.0.0-1.el7.src.rpm
INFO: Done(pkgs-1.0.0-1-epel-7-x86_64/confluent-libserdes-1.0.0-1.el7.src.rpm) Config(epel-7-x86_64) 0 minutes 11 seconds
INFO: Results and/or logs in: pkgs-1.0.0-1-epel-7-x86_64
Finish: run
======= Binary RPMs now available in pkgs-1.0.0-1-epel-7-x86_64 =======
```

#### EL6

```
[root@ip-172-31-35-84 rpm]# ls $REPO_DIR/
avro-c-1.8.0-1.el6.src.rpm               avro-cpp-1.8.0-1.el6.x86_64.rpm            librdkafka-1.4.2-1.el6.src.rpm
avro-c-1.8.0-1.el6.x86_64.rpm            avro-cpp-debuginfo-1.8.0-1.el6.x86_64.rpm  librdkafka-debuginfo-1.4.2-1.el6.x86_64.rpm
avro-c-debuginfo-1.8.0-1.el6.x86_64.rpm  avro-cpp-devel-1.8.0-1.el6.x86_64.rpm      librdkafka-devel-1.4.2-1.el6.x86_64.rpm
avro-c-devel-1.8.0-1.el6.x86_64.rpm      avro-c-tools-1.8.0-1.el6.x86_64.rpm
avro-cpp-1.8.0-1.el6.src.rpm             librdkafka1-1.4.2-1.el6.x86_64.rpm
[root@ip-172-31-35-84 rpm]# make MOCK_CONFIG=epel-6-x86_64 install-deps all
[ -f pkgs-1.0.0-1-epel-6-x86_64/state.log ] || /usr/bin/mock -r epel-6-x86_64  \
	--resultdir=pkgs-1.0.0-1-epel-6-x86_64 --init
INFO: mock.py version 1.4.21 starting (python version = 3.6.8)...
...
/usr/bin/mock \
	 \
	-r epel-6-x86_64 \
	--no-clean \
	--no-cleanup-after \
	--resultdir=pkgs-1.0.0-1-epel-6-x86_64 \
	--install /tmp/_libserdes-deps/avro-c-1.8.0-1.el6.x86_64.rpm /tmp/_libserdes-deps/avro-c-devel-1.8.0-1.el6.x86_64.rpm /tmp/_libserdes-deps/avro-cpp-1.8.0-1.el6.x86_64.rpm /tmp/_libserdes-deps/avro-cpp-devel-1.8.0-1.el6.x86_64.rpm /tmp/_libserdes-deps/avro-c-tools-1.8.0-1.el6.x86_64.rpm /tmp/_libserdes-deps/librdkafka1-1.4.2-1.el6.x86_64.rpm /tmp/_libserdes-deps/librdkafka-devel-1.4.2-1.el6.x86_64.rpm
INFO: mock.py version 1.4.21 starting (python version = 3.6.8)...
...
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: libserdes++.so.1()(64bit) libserdes.so.1()(64bit)
Processing files: confluent-libserdes-debuginfo-1.0.0-1.el6.x86_64
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/confluent-libserdes-1.0.0-1.el6.x86_64
warning: Could not canonicalize hostname: ip-172-31-35-84.us-west-2.compute.internal
Wrote: /builddir/build/RPMS/confluent-libserdes-1.0.0-1.el6.x86_64.rpm
Wrote: /builddir/build/RPMS/confluent-libserdes-devel-1.0.0-1.el6.x86_64.rpm
Wrote: /builddir/build/RPMS/confluent-libserdes-debuginfo-1.0.0-1.el6.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.94TRIR
+ umask 022
+ cd /builddir/build/BUILD
+ cd confluent-libserdes-1.0.0
+ rm -rf /builddir/build/BUILDROOT/confluent-libserdes-1.0.0-1.el6.x86_64
+ exit 0
Finish: rpmbuild confluent-libserdes-1.0.0-1.el6.src.rpm
Finish: build phase for confluent-libserdes-1.0.0-1.el6.src.rpm
INFO: Done(pkgs-1.0.0-1-epel-6-x86_64/confluent-libserdes-1.0.0-1.el6.src.rpm) Config(epel-6-x86_64) 0 minutes 7 seconds
INFO: Results and/or logs in: pkgs-1.0.0-1-epel-6-x86_64
Finish: run
======= Binary RPMs now available in pkgs-1.0.0-1-epel-6-x86_64 =======
```