### PR TITLE
Add support for SSL registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,8 @@ to the schema registries, all other configuration is optional.
  * `schema.registry.url` - comma separated list of schema registry base URLs (no default)
  * `deserializer.framing` - expected framing format when deserializing data: `none` or `cp1` (Confluent Platform framing). (default: `cp1`)
  * `serializer.framing` - framing format inserted when serializing data: `none` or `cp1` (Confluent Platform framing). (default: `cp1`)
+ * `ssl.ca.location` - location to the CA certificate (no default)
+ * `ssl.certificate.location` - location to the client certificate. (no default)
+ * `ssl.key.location` - location to the private key. (no default)
+ * `ssl.enabled.min_protocol` - the minimal tls version to use. The value can be `1.0`, `1.1`, `1.2` or `1.3`. (no default)
  * `debug` - enable/disable debugging with `all` or `none`. (default: `none`)

--- a/src/rest.h
+++ b/src/rest.h
@@ -36,6 +36,17 @@ typedef struct url_list_s {
         int    max_len;       /* Longest URL's length */
 } url_list_t;
 
+/**
+ * HTTP security related information. SSL/Auth/etc.
+ */
+typedef struct security_info_s {
+        char  *ca_path;
+        char  *cert_path;
+        char  *key_path;
+        /* CURLOPT_SSLVERSION */
+        int   min_tls_version;
+} security_info_t;
+
 
 /**
  * Parse a comma-separated list of URLs and store them in the provided 'ul'.
@@ -101,7 +112,9 @@ void rest_response_destroy (rest_response_t *rr);
  *
  * This is a blocking call.
  */
-rest_response_t *rest_get (url_list_t *ul, const char *url_path_fmt, ...);
+rest_response_t *rest_get (url_list_t *ul,
+                           const security_info_t *secure_info,
+                           const char *url_path_fmt, ...);
 
 
 /* REST PUT request.
@@ -109,6 +122,7 @@ rest_response_t *rest_get (url_list_t *ul, const char *url_path_fmt, ...);
  * Same semantics as `rest_get()` but POSTs `payload` of `size` bytes.
  */
 rest_response_t *rest_post (url_list_t *ul,
+                            const security_info_t *secure_info,
                             const void *payload, int size,
                             const char *url_path_fmt, ...);
 

--- a/src/schema-cache.c
+++ b/src/schema-cache.c
@@ -120,7 +120,9 @@ static int serdes_schema_store (serdes_schema_t *ss,
         enc_len = strlen(enc);
 
         /* POST schema definition to remote schema registry */
-        rr = rest_post(&sd->sd_conf.schema_registry_urls, enc, enc_len,
+        rr = rest_post(&sd->sd_conf.schema_registry_urls,
+                       &sd->sd_conf.schema_security_info,
+                       enc, enc_len,
                        "/subjects/%s/versions", ss->ss_name);
 
         free(enc);
@@ -241,10 +243,12 @@ static int serdes_schema_fetch (serdes_schema_t *ss,
         if (ss->ss_id != -1) {
                 /* GET schema definition by id from remote schema registry */
                 rr = rest_get(&sd->sd_conf.schema_registry_urls,
+                              &sd->sd_conf.schema_security_info,
                               "/schemas/ids/%d", ss->ss_id);
         } else {
                 /* GET schema definition by name from remote schema registry */
                 rr = rest_get(&sd->sd_conf.schema_registry_urls,
+                              &sd->sd_conf.schema_security_info,
                               "/subjects/%s/versions/latest", ss->ss_name);
         }
 

--- a/src/serdes_int.h
+++ b/src/serdes_int.h
@@ -55,6 +55,7 @@ typedef enum {
 struct serdes_conf_s {
         url_list_t  schema_registry_urls;      /* CSV list of schema
                                                 * registry URLs. */
+        security_info_t schema_security_info;  /* Security information (SSL/Auth/etc.) */
         int         debug;                     /* Debugging 1=enabled */
 
 


### PR DESCRIPTION
- Add option 'ssl.ca.location', 'ssl.certificate.location',
  'ssl.key.location' and 'ssl.enabled.min_protocol' to support SSL
  enabled registry service.

Limitations:
- 'schema.registry.url' accepts multiple URLs separated by ','. But
  the options added by this commit don't. That means all the URLs will
  use the same SSL information provided by those options.

Close #7
