### PR TITLE
fix: Add pkgconfig to devel package

### DIFF
--- a/rpm/confluent-libserdes.spec
+++ b/rpm/confluent-libserdes.spec
@@ -51,13 +51,17 @@ rm -rf %{buildroot}
 
 
 %files devel
-%defattr(444,root,root)
+%defattr(-,root,root)
 %{_includedir}/libserdes
+%defattr(444,root,root)
 %{_libdir}/libserdes.a
 %{_libdir}/libserdes.so
 %{_libdir}/libserdes++.a
 %{_libdir}/libserdes++.so
-%{_libdir}/pkgconfig/serdes*.pc
+%{_libdir}/pkgconfig/serdes++.pc
+%{_libdir}/pkgconfig/serdes++-static.pc
+%{_libdir}/pkgconfig/serdes.pc
+%{_libdir}/pkgconfig/serdes-static.pc
 %doc LICENSE README.md
 
 

--- a/rpm/confluent-libserdes.spec
+++ b/rpm/confluent-libserdes.spec
@@ -57,6 +57,7 @@ rm -rf %{buildroot}
 %{_libdir}/libserdes.so
 %{_libdir}/libserdes++.a
 %{_libdir}/libserdes++.so
+%{_libdir}/pkgconfig/serdes*.pc
 %doc LICENSE README.md
 
 


### PR DESCRIPTION
Rpm Packaging of the master branch is throwing the error:

```
08:58:03  Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/confluent-libserdes-7.2.0-0.1.0.el7.x86_64
08:58:03  error: Installed (but unpackaged) file(s) found:
08:58:03     /usr/lib64/pkgconfig/serdes++-static.pc
08:58:03     /usr/lib64/pkgconfig/serdes++.pc
08:58:03     /usr/lib64/pkgconfig/serdes-static.pc
08:58:03     /usr/lib64/pkgconfig/serdes.pc
08:58:03      %defattr doesn't define directory mode so file mode defined in %defattr is used for directory: /builddir/build/BUILDROOT/confluent-libserdes-7.2.0-0.1.0.el7.x86_64/usr/include/libserdes
08:58:03      %defattr doesn't define directory mode so file mode defined in %defattr is used for directory: /builddir/build/BUILDROOT/confluent-libserdes-7.2.0-0.1.0.el7.x86_64/usr/share/doc/confluent-libserdes-devel-7.2.0
08:58:03      Installed (but unpackaged) file(s) found:
08:58:03     /usr/lib64/pkgconfig/serdes++-static.pc
08:58:03     /usr/lib64/pkgconfig/serdes++.pc
08:58:03     /usr/lib64/pkgconfig/serdes-static.pc
08:58:03     /usr/lib64/pkgconfig/serdes.pc
```

So this change fixes that.