### PR TITLE
Win support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,222 @@
+cmake_minimum_required(VERSION 3.23.0)
+project(libserdes)
+
+option(SERDES_ENABLE_AVRO_C "Include avro C facilities" OFF)
+option(SERDES_ENABLE_AVRO_CPP "Include avro C++ facilities" ON)
+option(SERDES_ENABLE_WITH_EXAMPLE "Build examples" OFF)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+if(SERDES_ENABLE_AVRO_CPP)
+  find_package(libavrocpp REQUIRED)
+endif()
+find_package(jansson REQUIRED)
+find_package(CURL REQUIRED)
+
+# Serdes common base library
+# --------------------------
+set(SERDES_COMMON_PUBLIC_HEADERS
+  src/serdes.h
+  src/serdes-common.h
+)
+
+set(SERDES_COMMON_SRC
+  src/framing.c
+  src/rest.c
+  src/rest.h
+  src/schema-cache.c
+  src/serdes.c
+  src/serdes_int.h
+  src/tinycthread.h
+)
+
+# Serdes C thread library
+# -----------------------
+add_library(serdes_c_thread STATIC
+  src/tinycthread.c
+  src/tinycthread.h
+)
+
+target_compile_features(serdes_c_thread PUBLIC c_std_99)
+# C_STANDARD required for macOS
+set_target_properties(serdes_c_thread PROPERTIES
+  C_STANDARD 99
+  C_STANDARD_REQUIRED ON
+  C_EXTENSIONS OFF
+  LINKER_LANGUAGE C
+  FOLDER "Serdes"
+)
+
+# Serdes C library
+# ----------------
+add_library(serdes STATIC)
+
+target_compile_features(serdes PUBLIC c_std_99)
+# C_STANDARD required for macOS
+set_target_properties(serdes PROPERTIES
+  C_STANDARD 99
+  C_STANDARD_REQUIRED ON
+  C_EXTENSIONS OFF
+  LINKER_LANGUAGE C
+  FOLDER "Serdes"
+)
+
+target_compile_definitions(serdes PRIVATE HAVE_NO_CONFIG)
+
+target_include_directories(serdes
+PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<INSTALL_INTERFACE:include>
+PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/windows/include>
+)
+
+IF (WIN32)
+  target_include_directories(serdes
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/windows/include>
+  )
+ENDIF()
+
+target_sources(serdes
+PUBLIC
+FILE_SET serdes_api
+TYPE HEADERS
+BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src
+FILES
+  ${SERDES_COMMON_PUBLIC_HEADERS}
+  src/serdes.h
+PRIVATE
+  ${SERDES_COMMON_SRC}
+)
+
+target_link_libraries(serdes
+PRIVATE
+  CURL::libcurl
+  jansson::jansson
+)
+
+if(SERDES_ENABLE_AVRO_C)
+  target_compile_definitions(serdes PUBLIC ENABLE_AVRO_C)
+
+  target_sources(serdes
+  PUBLIC
+  FILE_SET serdes_api
+  TYPE HEADERS
+  BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src
+  FILES
+    src/serdes-avro.h
+  PRIVATE
+    src/deserialize-avro.c
+    src/schema-avro.c
+    src/serialize-avro.c
+  )
+
+  target_link_libraries(serdes
+  PUBLIC
+    avro-static
+  )
+endif()
+
+# Serdes C++ thread library
+# -----------------------
+add_library(serdes_cxx_thread STATIC
+  src/tinycthread.c
+  src/tinycthread.h
+)
+
+target_compile_features(serdes_cxx_thread PUBLIC cxx_std_11)
+# CXX_STANDARD required for macOS
+set_target_properties(serdes_cxx_thread PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  FOLDER "Serdes"
+)
+
+# Serdes C++ library
+# ------------------
+add_library(serdes++ STATIC)
+
+target_compile_features(serdes++ PUBLIC cxx_std_11)
+# CXX_STANDARD required for macOS
+set_target_properties(serdes++ PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  FOLDER "Serdes"
+)
+
+target_compile_definitions(serdes++ PRIVATE HAVE_NO_CONFIG)
+
+target_include_directories(serdes++
+PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src-cpp>
+  $<INSTALL_INTERFACE:include>
+PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+)
+
+IF (WIN32)
+  target_include_directories(serdes++
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/windows/include>
+  )
+ENDIF()
+
+target_sources(serdes++
+PUBLIC
+FILE_SET serdes_api
+TYPE HEADERS
+BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src
+FILES
+  ${SERDES_COMMON_PUBLIC_HEADERS}
+PUBLIC
+FILE_SET serdes_api
+TYPE HEADERS
+BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src-cpp
+FILES
+  src-cpp/serdescpp.h
+PRIVATE
+  ${SERDES_COMMON_SRC}
+  src-cpp/Serdes.cpp
+  src-cpp/serdescpp_int.h
+)
+
+target_link_libraries(serdes++
+PRIVATE
+  CURL::libcurl
+  jansson::jansson
+)
+
+if(SERDES_ENABLE_AVRO_CPP)
+  target_sources(serdes++
+  PUBLIC
+  FILE_SET serdes_api
+  TYPE HEADERS
+  BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src-cpp
+  FILES
+    src-cpp/serdescpp-avro.h
+  PRIVATE
+    src-cpp/serdescpp-avro_int.h
+    src-cpp/serdes-avro.cpp
+  )
+
+  target_link_libraries(serdes++
+  PUBLIC
+    libavrocpp::libavrocpp
+  )
+endif()
+
+# TODO install directory: include/libserdes
+include(GNUInstallDirs)
+install(TARGETS
+  serdes serdes_c_thread
+  serdes++ serdes_cxx_thread
+  FILE_SET serdes_api
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libserdes
+)
+
+if(SERDES_ENABLE_WITH_EXAMPLE)
+  add_subdirectory(examples)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libserdes
 
-Copyright(C) 2015-2022 Confluent Inc.
+Copyright(C) 2015-2023 Confluent Inc.
 
  * This software is licensed under the Apache 2.0 license.
 ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -49,17 +49,36 @@ On Debian/Ubuntu based systems:
  **NOTE: The avro libraries needs to be installed manually or through [Confluent's APT and YUM repositories](http://docs.confluent.io/current/installation.html)**
 
 ## Build
+### Configure script (Linux)
 
     ./configure
     make
     sudo make install
 
+### CMake - Conan
 
-### Documentation
+    mkdir build
+    cd build
+    conan install -pr:b win_x86_64_release -pr:h win_x86_64_release ../conan/conanfile.txt
+    cmake .. --toolchain=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+    cmake -P cmake_install.cmake
+
+profile `win_x86_64_release` is provided as example in `conan` directory.
+
+Build options: 
+
+| Option                            | Description                 | Default |
+| :-------------------------------- | :-------------------------- | :-----: |
+| SERDES_ENABLE_AVRO_C              | Include avro C facilities   | OFF     |
+| SERDES_ENABLE_AVRO_CPP            | Include avro C++ facilities | ON      |
+| SERDES_ENABLE_WITH_EXAMPLE        | Build examples              | OFF     |
+| SERDES_ENABLE_EXAMPLES_LIBRDKAFKA | Include examples with kafka | OFF     |
+
+## Documentation
 
 Full API documentation is available in [serdes.h](src/serdes.h) and [serdescpp.h](src-cpp/serdescpp.h)
 
-### Configuration
+## Configuration
 
 libserdes typically only needs to be configured with a list of URLs
 to the schema registries, all other configuration is optional.

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,0 +1,15 @@
+[requires]
+libavrocpp/1.11.1
+libcurl/7.88.1
+jansson/2.14
+openssl/1.1.1t
+
+librdkafka/1.9.2
+
+[generators]
+CMakeToolchain
+CMakeDeps
+
+[options]
+libcurl:with_ssl=openssl
+openssl:shared=True

--- a/conan/win_x86_64_release
+++ b/conan/win_x86_64_release
@@ -1,0 +1,9 @@
+[settings]
+os=Windows
+arch=x86_64
+compiler=Visual Studio
+compiler.version=17
+build_type=Release
+[options]
+[build_requires]
+[env]

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,108 @@
+cmake_minimum_required(VERSION 3.23.0)
+project(libserdes-examples)
+
+option(SERDES_ENABLE_EXAMPLES_LIBRDKAFKA "Include examples with kafka" OFF)
+
+# Serdes tool
+# -----------
+add_executable(serdes-tool
+  serdes-tool.cpp
+)
+
+target_compile_features(serdes-tool PUBLIC cxx_std_11)
+set_target_properties(serdes-tool PROPERTIES
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  FOLDER "Examples"
+)
+
+target_include_directories(serdes-tool
+PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
+
+IF (WIN32)
+  target_include_directories(serdes-tool
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/windows>
+  )
+ENDIF()
+
+target_link_libraries(serdes-tool
+PRIVATE
+  serdes_cxx_thread
+  serdes++
+)
+
+if(SERDES_ENABLE_EXAMPLES_LIBRDKAFKA)
+  find_package(RdKafka REQUIRED)
+  
+  # Kafka console to consume avro with serdes avro
+  # ----------------------------------------------
+  add_executable(kafka-serdes-avro-console-consumer
+    kafka-serdes-avro-console-consumer.cpp
+  )
+
+  target_compile_features(kafka-serdes-avro-console-consumer PUBLIC cxx_std_11)
+  set_target_properties(kafka-serdes-avro-console-consumer PROPERTIES
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+    FOLDER "Examples"
+  )
+  
+  target_include_directories(kafka-serdes-avro-console-consumer
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+  )
+  
+  IF (WIN32)
+    target_include_directories(kafka-serdes-avro-console-consumer
+    PRIVATE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/windows>
+  )
+  ENDIF()
+  
+  target_link_libraries(kafka-serdes-avro-console-consumer
+  PRIVATE
+    serdes++
+    RdKafka::rdkafka++
+  )
+
+  # Kafka console to produce avro with serdes avro
+  # ----------------------------------------------
+  add_executable(kafka-serdes-avro-console-producer
+    kafka-serdes-avro-console-producer.cpp
+  )
+
+  target_compile_features(kafka-serdes-avro-console-producer PUBLIC cxx_std_11)
+  set_target_properties(kafka-serdes-avro-console-producer PROPERTIES
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+    FOLDER "Examples"
+  )
+  
+  target_include_directories(kafka-serdes-avro-console-producer
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+  )
+  
+  IF (WIN32)
+    target_include_directories(kafka-serdes-avro-console-producer
+    PRIVATE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/windows>
+  )
+  ENDIF()
+  
+  target_link_libraries(kafka-serdes-avro-console-producer
+  PRIVATE
+    serdes++
+    RdKafka::rdkafka++
+  )
+
+  # TODO rdkafka c and serdes
+  # serdes-kafka-avro-client.c
+
+endif()

--- a/examples/kafka-serdes-avro-console-consumer.cpp
+++ b/examples/kafka-serdes-avro-console-consumer.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/kafka-serdes-avro-console-consumer.cpp
+++ b/examples/kafka-serdes-avro-console-consumer.cpp
@@ -28,7 +28,9 @@
 #include <signal.h>
 #include <getopt.h>
 
-#include <netinet/in.h> // remove
+#ifndef _WIN32
+  #include <netinet/in.h> // remove
+#endif
 
 /* Typical include path is <libserdes/serdescpp-avro.h> */
 #include "../src-cpp/serdescpp-avro.h"
@@ -52,8 +54,8 @@ static int payload_serialized = 0;
 static int key_serialized = 0;
 
 
-#define FATAL(reason...) do {                           \
-    std::cerr << "% FATAL: " << reason << std::endl;      \
+#define FATAL(...) do {                           \
+    std::cerr << "% FATAL: " << __VA_ARGS__ << std::endl;      \
     exit(1);                                            \
   } while (0)
 
@@ -182,7 +184,7 @@ static void msg_handle (RdKafka::Message *msg) {
 
 
 
-static __attribute__((noreturn))
+[[noreturn]] static
 void usage (const std::string me) {
 
   std::cerr <<
@@ -212,12 +214,17 @@ int main (int argc, char **argv) {
   std::string errstr;
 
   /* Controlled termination */
+#ifdef _WIN32
+  signal(SIGINT, sig_term);
+  signal(SIGTERM, sig_term);
+  signal(SIGABRT, sig_term);
+#else
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = sig_term;
   sigaction(SIGINT, &sa, NULL);
   sigaction(SIGTERM, &sa, NULL);
-
+#endif
 
   /* Create serdes configuration object.
    * Configuration passed through -X prop=val will be set on this object,

--- a/examples/kafka-serdes-avro-console-producer.cpp
+++ b/examples/kafka-serdes-avro-console-producer.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/kafka-serdes-avro-console-producer.cpp
+++ b/examples/kafka-serdes-avro-console-producer.cpp
@@ -44,15 +44,10 @@
 static bool run = true;
 static int verbosity = 2;
 
-#define FATAL(reason...) do {                           \
-    std::cerr << "% FATAL: " << reason << std::endl;      \
+#define FATAL(...) do {                           \
+    std::cerr << "% FATAL: " << __VA_ARGS__ << std::endl;      \
     exit(1);                                            \
   } while (0)
-
-
-
-
-
 
 
 class MyDeliveryReportCb : public RdKafka::DeliveryReportCb {
@@ -109,7 +104,7 @@ static int json2avro (Serdes::Schema *schema, const std::string &json,
 }
 
 
-static __attribute__((noreturn))
+[[noreturn]] static
 void usage (const std::string me) {
 
   std::cerr <<
@@ -154,11 +149,17 @@ int main (int argc, char **argv) {
   int partition = -1;
 
   /* Controlled termination */
+#ifdef _WIN32
+  signal(SIGINT, sig_term);
+  signal(SIGTERM, sig_term);
+  signal(SIGABRT, sig_term);
+#else
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = sig_term;
   sigaction(SIGINT, &sa, NULL);
   sigaction(SIGTERM, &sa, NULL);
+#endif
 
 
   /* Create serdes configuration object.

--- a/examples/serdes-tool.cpp
+++ b/examples/serdes-tool.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/serdes-tool.cpp
+++ b/examples/serdes-tool.cpp
@@ -28,14 +28,14 @@
 
 #include <avro/Decoder.hh>
 
-/* Typical include path is <libserdes/serdescpp.h> */
-#include "../src-cpp/serdescpp.h"
+/* Typical include path is <libserdes/serdescpp-avro.h> */
+#include "../src-cpp/serdescpp-avro.h"
 
 static int run = 1;
 static int verbosity = 2;
 
-#define FATAL(reason...) do {                           \
-    std::cerr << "FATAL: " << reason << std::endl;      \
+#define FATAL(...) do {                           \
+    std::cerr << "FATAL: " << __VA_ARGS__ << std::endl;      \
     exit(1);                                            \
   } while (0)
 
@@ -111,12 +111,17 @@ int main (int argc, char **argv) {
 
 
   /* Controlled termination */
+#ifdef _WIN32
+  signal(SIGINT, sig_term);
+  signal(SIGTERM, sig_term);
+  signal(SIGABRT, sig_term);
+#else
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = sig_term;
   sigaction(SIGINT, &sa, NULL);
   sigaction(SIGTERM, &sa, NULL);
-
+#endif
 
   /* Create serdes configuration object.
    * Configuration passed through -X prop=val will be set on this object,
@@ -185,7 +190,7 @@ int main (int argc, char **argv) {
   /*
    * Create serdes handle
    */
-  Serdes::Handle *serdes = Serdes::Handle::create(sconf, errstr);
+  Serdes::Handle *serdes = Serdes::Avro::create(sconf, errstr);
   if (!serdes)
     FATAL("Failed to create serdes handle: " << errstr);
 

--- a/examples/windows/getopt.h
+++ b/examples/windows/getopt.h
@@ -1,0 +1,653 @@
+#ifndef __GETOPT_H__
+/**
+ * DISCLAIMER
+ * This file is part of the mingw-w64 runtime package.
+ *
+ * The mingw-w64 runtime package and its code is distributed in the hope that it 
+ * will be useful but WITHOUT ANY WARRANTY.  ALL WARRANTIES, EXPRESSED OR 
+ * IMPLIED ARE HEREBY DISCLAIMED.  This includes but is not limited to 
+ * warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+ /*
+ * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Sponsored in part by the Defense Advanced Research Projects
+ * Agency (DARPA) and Air Force Research Laboratory, Air Force
+ * Materiel Command, USAF, under agreement number F39502-99-1-0512.
+ */
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma warning(disable:4996)
+
+#define __GETOPT_H__
+
+/* All the headers include this file. */
+#include <crtdefs.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define	REPLACE_GETOPT		/* use this getopt as the system getopt(3) */
+
+#ifdef REPLACE_GETOPT
+int	opterr = 1;		/* if error message should be printed */
+int	optind = 1;		/* index into parent argv vector */
+int	optopt = '?';		/* character checked for validity */
+#undef	optreset		/* see getopt.h */
+#define	optreset		__mingw_optreset
+int	optreset;		/* reset getopt */
+char    *optarg;		/* argument associated with option */
+#endif
+
+//extern int optind;		/* index of first non-option in argv      */
+//extern int optopt;		/* single option character, as parsed     */
+//extern int opterr;		/* flag to enable built-in diagnostics... */
+//				/* (user may set to zero, to suppress)    */
+//
+//extern char *optarg;		/* pointer to argument of current option  */
+
+#define PRINT_ERROR	((opterr) && (*options != ':'))
+
+#define FLAG_PERMUTE	0x01	/* permute non-options to the end of argv */
+#define FLAG_ALLARGS	0x02	/* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY	0x04	/* operate as getopt_long_only */
+
+/* return values */
+#define	BADCH		(int)'?'
+#define	BADARG		((*options == ':') ? (int)':' : (int)'?')
+#define	INORDER 	(int)1
+
+#ifndef __CYGWIN__
+#define __progname __argv[0]
+#else
+extern char __declspec(dllimport) *__progname;
+#endif
+
+#ifdef __CYGWIN__
+static char EMSG[] = "";
+#else
+#define	EMSG		""
+#endif
+
+static int getopt_internal(int, char * const *, const char *,
+			   const struct option *, int *, int);
+static int parse_long_options(char * const *, const char *,
+			      const struct option *, int *, int);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+static void
+_vwarnx(const char *fmt,va_list ap)
+{
+  (void)fprintf(stderr,"%s: ",__progname);
+  if (fmt != NULL)
+    (void)vfprintf(stderr,fmt,ap);
+  (void)fprintf(stderr,"\n");
+}
+
+static void
+warnx(const char *fmt,...)
+{
+  va_list ap;
+  va_start(ap,fmt);
+  _vwarnx(fmt,ap);
+  va_end(ap);
+}
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return (b);
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(int panonopt_start, int panonopt_end, int opt_end,
+	char * const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **) nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+#ifdef REPLACE_GETOPT
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the BSD getopt]
+ */
+int
+getopt(int nargc, char * const *nargv, const char *options)
+{
+
+	/*
+	 * We don't pass FLAG_PERMUTE to getopt_internal() since
+	 * the BSD getopt(3) (unlike GNU) has never done this.
+	 *
+	 * Furthermore, since many privileged programs call getopt()
+	 * before dropping privileges it makes sense to keep things
+	 * as simple (and bug-free) as possible.
+	 */
+	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+}
+#endif /* REPLACE_GETOPT */
+
+//extern int getopt(int nargc, char * const *nargv, const char *options);
+
+#ifdef _BSD_SOURCE
+/*
+ * BSD adds the non-standard `optreset' feature, for reinitialisation
+ * of `getopt' parsing.  We support this feature, for applications which
+ * proclaim their BSD heritage, before including this header; however,
+ * to maintain portability, developers are advised to avoid it.
+ */
+# define optreset  __mingw_optreset
+extern int optreset;
+#endif
+#ifdef __cplusplus
+}
+#endif
+/*
+ * POSIX requires the `getopt' API to be specified in `unistd.h';
+ * thus, `unistd.h' includes this header.  However, we do not want
+ * to expose the `getopt_long' or `getopt_long_only' APIs, when
+ * included in this manner.  Thus, close the standard __GETOPT_H__
+ * declarations block, and open an additional __GETOPT_LONG_H__
+ * specific block, only when *not* __UNISTD_H_SOURCED__, in which
+ * to declare the extended API.
+ */
+#endif /* !defined(__GETOPT_H__) */
+
+#if !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__)
+#define __GETOPT_LONG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct option		/* specification for a long form option...	*/
+{
+  const char *name;		/* option name, without leading hyphens */
+  int         has_arg;		/* does it take an argument?		*/
+  int        *flag;		/* where to save its status, or NULL	*/
+  int         val;		/* its associated status value		*/
+};
+
+enum    		/* permitted values for its `has_arg' field...	*/
+{
+  no_argument = 0,      	/* option never takes an argument	*/
+  required_argument,		/* option always requires an argument	*/
+  optional_argument		/* option may take an argument		*/
+};
+
+/*
+ * parse_long_options --
+ *	Parse long options in argc/argv argument vector.
+ * Returns -1 if short_too is set and the option does not match long_options.
+ */
+static int
+parse_long_options(char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int short_too)
+{
+	char *current_argv, *has_equal;
+	size_t current_argv_len;
+	int i, ambiguous, match;
+
+#define IDENTICAL_INTERPRETATION(_x, _y)                                \
+	(long_options[(_x)].has_arg == long_options[(_y)].has_arg &&    \
+	 long_options[(_x)].flag == long_options[(_y)].flag &&          \
+	 long_options[(_x)].val == long_options[(_y)].val)
+
+	current_argv = place;
+	match = -1;
+	ambiguous = 0;
+
+	optind++;
+
+	if ((has_equal = strchr(current_argv, '=')) != NULL) {
+		/* argument found (--option=arg) */
+		current_argv_len = has_equal - current_argv;
+		has_equal++;
+	} else
+		current_argv_len = strlen(current_argv);
+
+	for (i = 0; long_options[i].name; i++) {
+		/* find matching long option */
+		if (strncmp(current_argv, long_options[i].name,
+		    current_argv_len))
+			continue;
+
+		if (strlen(long_options[i].name) == current_argv_len) {
+			/* exact match */
+			match = i;
+			ambiguous = 0;
+			break;
+		}
+		/*
+		 * If this is a known short option, don't allow
+		 * a partial match of a single character.
+		 */
+		if (short_too && current_argv_len == 1)
+			continue;
+
+		if (match == -1)	/* partial match */
+			match = i;
+		else if (!IDENTICAL_INTERPRETATION(i, match))
+			ambiguous = 1;
+	}
+	if (ambiguous) {
+		/* ambiguous abbreviation */
+		if (PRINT_ERROR)
+			warnx(ambig, (int)current_argv_len,
+			     current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (match != -1) {		/* option found */
+		if (long_options[match].has_arg == no_argument
+		    && has_equal) {
+			if (PRINT_ERROR)
+				warnx(noarg, (int)current_argv_len,
+				     current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			return (BADARG);
+		}
+		if (long_options[match].has_arg == required_argument ||
+		    long_options[match].has_arg == optional_argument) {
+			if (has_equal)
+				optarg = has_equal;
+			else if (long_options[match].has_arg ==
+			    required_argument) {
+				/*
+				 * optional argument doesn't use next nargv
+				 */
+				optarg = nargv[optind++];
+			}
+		}
+		if ((long_options[match].has_arg == required_argument)
+		    && (optarg == NULL)) {
+			/*
+			 * Missing argument; leading ':' indicates no error
+			 * should be generated.
+			 */
+			if (PRINT_ERROR)
+				warnx(recargstring,
+				    current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			--optind;
+			return (BADARG);
+		}
+	} else {			/* unknown option */
+		if (short_too) {
+			--optind;
+			return (-1);
+		}
+		if (PRINT_ERROR)
+			warnx(illoptstring, current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (idx)
+		*idx = match;
+	if (long_options[match].flag) {
+		*long_options[match].flag = long_options[match].val;
+		return (0);
+	} else
+		return (long_options[match].val);
+#undef IDENTICAL_INTERPRETATION
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ */
+static int
+getopt_internal(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int flags)
+{
+	char *oli;				/* option letter list index */
+	int optchar, short_too;
+	static int posixly_correct = -1;
+
+	if (options == NULL)
+		return (-1);
+
+	/*
+	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
+	 * XXX using optreset.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = optreset = 1;
+
+	/*
+	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
+	 * string begins with a '+'.
+	 *
+	 * CV, 2009-12-14: Check POSIXLY_CORRECT anew if optind == 0 or
+	 *                 optreset != 0 for GNU compatibility.
+	 */
+	if (posixly_correct == -1 || optreset != 0)
+		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+	if (*options == '-')
+		flags |= FLAG_ALLARGS;
+	else if (posixly_correct || *options == '+')
+		flags &= ~FLAG_PERMUTE;
+	if (*options == '+' || *options == '-')
+		options++;
+
+	optarg = NULL;
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+		if (*(place = nargv[optind]) != '-' ||
+		    (place[1] == '\0' && strchr(options, '-') == NULL)) {
+			place = EMSG;		/* found non-option */
+			if (flags & FLAG_ALLARGS) {
+				/*
+				 * GNU extension:
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return (INORDER);
+			}
+			if (!(flags & FLAG_PERMUTE)) {
+				/*
+				 * If no permutation wanted, stop parsing
+				 * at first non-option.
+				 */
+				return (-1);
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+
+		/*
+		 * If we have "-" do nothing, if "--" we are done.
+		 */
+		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+			optind++;
+			place = EMSG;
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+	}
+
+	/*
+	 * Check long options if:
+	 *  1) we were passed some
+	 *  2) the arg is not just "-"
+	 *  3) either the arg starts with -- we are getopt_long_only()
+	 */
+	if (long_options != NULL && place != nargv[optind] &&
+	    (*place == '-' || (flags & FLAG_LONGONLY))) {
+		short_too = 0;
+		if (*place == '-')
+			place++;		/* --foo long option */
+		else if (*place != ':' && strchr(options, *place) != NULL)
+			short_too = 1;		/* could be short option too */
+
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, short_too);
+		if (optchar != -1) {
+			place = EMSG;
+			return (optchar);
+		}
+	}
+
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (optchar == (int)'-' && *place != '\0') ||
+	    (oli = (char*)strchr(options, optchar)) == NULL) {
+		/*
+		 * If the user specified "-" and  '-' isn't listed in
+		 * options, return -1 (non-option) as per POSIX.
+		 * Otherwise, it is an unknown option character (or ':').
+		 */
+		if (optchar == (int)'-' && *place == '\0')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+		optopt = optchar;
+		return (BADCH);
+	}
+	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+		/* -W long-option */
+		if (*place)			/* no space */
+			/* NOTHING */;
+		else if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+			optopt = optchar;
+			return (BADARG);
+		} else				/* white space */
+			place = nargv[optind];
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, 0);
+		place = EMSG;
+		return (optchar);
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+				optopt = optchar;
+				return (BADARG);
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return (optchar);
+}
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE));
+}
+
+/*
+ * getopt_long_only --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long_only(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE|FLAG_LONGONLY));
+}
+
+//extern int getopt_long(int nargc, char * const *nargv, const char *options,
+//    const struct option *long_options, int *idx);
+//extern int getopt_long_only(int nargc, char * const *nargv, const char *options,
+//    const struct option *long_options, int *idx);
+/*
+ * Previous MinGW implementation had...
+ */
+#ifndef HAVE_DECL_GETOPT
+/*
+ * ...for the long form API only; keep this for compatibility.
+ */
+# define HAVE_DECL_GETOPT	1
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__) */

--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -2,7 +2,7 @@ PKGNAME=	libserdes
 LIBNAME=	libserdes++
 LIBVER=		1
 
-CXXSRCS=	Serdes.cpp
+CXXSRCS=	Serdes.cpp serdes-avro.cpp
 HDRS=		serdescpp.h serdescpp-avro.h
 
 OBJS=		$(CXXSRCS:%.cpp=%.o)

--- a/src-cpp/Serdes.cpp
+++ b/src-cpp/Serdes.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src-cpp/Serdes.cpp
+++ b/src-cpp/Serdes.cpp
@@ -17,15 +17,6 @@
 #include <cstdio>
 #include <exception>
 
-#include <avro/Compiler.hh>
-#include <avro/Encoder.hh>
-#include <avro/Decoder.hh>
-#include <avro/Generic.hh>
-#include <avro/Specific.hh>
-#include <avro/Exception.hh>
-
-#include "serdescpp.h"
-#include "serdescpp-avro.h"
 #include "serdescpp_int.h"
 
 
@@ -39,38 +30,10 @@ static void log_cb_trampoline (serdes_t *sd, int level,
   hnd->log_cb_->log_cb(hnd, level, fac, buf);
 }
 
-static void *schema_load_cb_trampoline (serdes_schema_t *schema,
-                                        const char *definition,
-                                        size_t definition_len,
-                                        char *errstr, size_t errstr_size,
-                                        void *opaque) {
-  avro::ValidSchema *avro_schema = new(avro::ValidSchema);
-
-  try {
-    *avro_schema = avro::compileJsonSchemaFromMemory((const uint8_t *)definition,
-                                                    definition_len);
-  } catch (const avro::Exception &e) {
-    snprintf(errstr, errstr_size, "Failed to compile JSON schema: %s",
-             e.what());
-    delete avro_schema;
-    return NULL;
-  }
-
-  return avro_schema;
-}
-
-static void schema_unload_cb_trampoline (serdes_schema_t *schema,
-                                         void *schema_obj, void *opaque) {
-  avro::ValidSchema *avro_schema = static_cast<avro::ValidSchema*>(schema_obj);
-  delete avro_schema;
-}
-
-
-
 /**
  * Common function to create a serdes handle based on conf.
  */
-static int create_serdes (HandleImpl *hnd, const Conf *conf, std::string &errstr) {
+int create_serdes (HandleImpl *hnd, const Conf *conf, std::string &errstr, schema_load_cb_t load_cb, schema_unload_cb_t unload_cb) {
   const ConfImpl *confimpl = conf ? dynamic_cast<const ConfImpl*>(conf) : NULL;
   serdes_conf_t *sconf;
   char c_errstr[256];
@@ -89,9 +52,7 @@ static int create_serdes (HandleImpl *hnd, const Conf *conf, std::string &errstr
     sconf = serdes_conf_new(NULL, 0, NULL);
   }
 
-  serdes_conf_set_schema_load_cb(sconf,
-                                 schema_load_cb_trampoline,
-                                 schema_unload_cb_trampoline);
+  serdes_conf_set_schema_load_cb(sconf, load_cb, unload_cb);
 
   hnd->sd_ = serdes_new(sconf, c_errstr, sizeof(c_errstr));
   if (!hnd->sd_) {
@@ -107,7 +68,7 @@ static int create_serdes (HandleImpl *hnd, const Conf *conf, std::string &errstr
 Handle *Handle::create (const Conf *conf, std::string &errstr) {
   HandleImpl *hnd = new HandleImpl();
 
-  if (create_serdes(hnd, conf, errstr) == -1) {
+  if (create_serdes(hnd, conf, errstr, NULL, NULL) == -1) {
     delete hnd;
     return NULL;
   }
@@ -127,8 +88,13 @@ Conf *Conf::create () {
 static Schema *schema_get (Handle *handle, const char *name, int id,
                            std::string &errstr) {
   HandleImpl *hnd = dynamic_cast<HandleImpl*>(handle);
+    
+  if (!hnd) {
+    errstr = "Unsupported schema handle";
+    return NULL;
+  }
+    
   char c_errstr[512];
-
   serdes_schema_t *c_schema = serdes_schema_get(hnd->sd_, name, id,
                                                 c_errstr, sizeof(c_errstr));
   if (!c_schema) {
@@ -141,7 +107,7 @@ static Schema *schema_get (Handle *handle, const char *name, int id,
   if (!schemaimpl) {
     schemaimpl = new SchemaImpl(c_schema);
     serdes_schema_set_opaque(c_schema, schemaimpl);
-}
+  }
 
   return schemaimpl;
 }
@@ -163,6 +129,12 @@ static Schema *schema_add (Handle *handle, const char* name, int id,
                            const void *definition, int definition_len,
                            std::string &errstr) {
   HandleImpl *hnd = dynamic_cast<HandleImpl*>(handle);
+    
+  if (!hnd) {
+    errstr = "Unsupported schema handle";
+    return NULL;
+  }
+    
   char c_errstr[512];
 
   serdes_schema_t *c_schema = serdes_schema_add(hnd->sd_, name, id,
@@ -196,109 +168,6 @@ Schema *Schema::add (Handle *handle, const std::string &name, int id,
                      std::string &errstr) {
   return schema_add(handle, name.c_str(), id,
                     definition.c_str(), definition.length(), errstr);
-}
-
-
-
-Serdes::Avro::~Avro () {
-
-}
-
-Avro *Avro::create (const Conf *conf, std::string &errstr) {
-  AvroImpl *avimpl = new AvroImpl();
-
-  if (create_serdes(avimpl, conf, errstr) == -1) {
-    delete avimpl;
-    return NULL;
-  }
-
-  return avimpl;
-}
-
-
-ssize_t AvroImpl::serialize (Schema *schema, const avro::GenericDatum *datum,
-                             std::vector<char> &out, std::string &errstr) {
-  auto avro_schema = schema->object();
-
-  /* Binary encoded output stream */
-  auto bin_os = avro::memoryOutputStream();
-  /* Avro binary encoder */
-  auto bin_encoder = avro::validatingEncoder(*avro_schema, avro::binaryEncoder());
-
-  try {
-    /* Encode Avro datum to Avro binary format */
-    bin_encoder->init(*bin_os.get());
-    avro::encode(*bin_encoder, *datum);
-    bin_encoder->flush();
-
-  } catch (const avro::Exception &e) {
-    errstr = std::string("Avro serialization failed: ") + e.what();
-    return -1;
-  }
-
-  /* Extract written bytes. */
-  auto encoded = avro::snapshot(*bin_os.get());
-
-  /* Write framing */
-  schema->framing_write(out);
-
-  /* Write binary encoded Avro to output vector */
-  out.insert(out.end(), encoded->cbegin(), encoded->cend());
-
-  return out.size();
-}
-
-
-ssize_t AvroImpl::deserialize (Schema **schemap, avro::GenericDatum **datump,
-                               const void *payload, size_t size,
-                               std::string &errstr) {
-  serdes_schema_t *ss;
-
-  /* Read framing */
-  char c_errstr[256];
-  ssize_t r = serdes_framing_read(sd_, &payload, &size, &ss,
-                                  c_errstr, sizeof(c_errstr));
-  if (r == -1) {
-    errstr = c_errstr;
-    return -1;
-  } else if (r == 0 && !*schemap) {
-    errstr = "Unable to decode payload: No framing and no schema specified";
-    return -1;
-  }
-
-  Schema *schema = *schemap;
-  if (!schema) {
-    schema = Serdes::Schema::get(dynamic_cast<HandleImpl*>(this),
-                                 serdes_schema_id(ss), errstr);
-    if (!schema)
-      return -1;
-  }
-
-  avro::ValidSchema *avro_schema = schema->object();
-
-  /* Binary input stream */
-  auto bin_is = avro::memoryInputStream((const uint8_t *)payload, size);
-
-  /* Binary Avro decoder */
-  avro::DecoderPtr bin_decoder = avro::validatingDecoder(*avro_schema,
-                                                         avro::binaryDecoder());
-
-  avro::GenericDatum *datum = new avro::GenericDatum(*avro_schema);
-
-  try {
-    /* Decode binary to Avro datum */
-    bin_decoder->init(*bin_is);
-    avro::decode(*bin_decoder, *datum);
-
-  } catch (const avro::Exception &e) {
-    errstr = std::string("Avro deserialization failed: ") + e.what();
-    delete datum;
-    return -1;
-  }
-
-  *schemap = schema;
-  *datump = datum;
-  return 0;
 }
 
 }

--- a/src-cpp/serdes-avro.cpp
+++ b/src-cpp/serdes-avro.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src-cpp/serdes-avro.cpp
+++ b/src-cpp/serdes-avro.cpp
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdio>
+#include <exception>
+
+#include <avro/Compiler.hh>
+#include <avro/Encoder.hh>
+#include <avro/Decoder.hh>
+#include <avro/Generic.hh>
+#include <avro/Specific.hh>
+#include <avro/Exception.hh>
+
+#include "serdescpp-avro_int.h"
+
+
+namespace Serdes {
+
+static void *schema_load_cb_trampoline (serdes_schema_t *schema,
+                                        const char *definition,
+                                        size_t definition_len,
+                                        char *errstr, size_t errstr_size,
+                                        void *opaque) {
+  avro::ValidSchema *avro_schema = new(avro::ValidSchema);
+
+  try {
+    *avro_schema = avro::compileJsonSchemaFromMemory((const uint8_t *)definition,
+                                                    definition_len);
+  } catch (const avro::Exception &e) {
+    snprintf(errstr, errstr_size, "Failed to compile JSON schema: %s",
+             e.what());
+    delete avro_schema;
+    return NULL;
+  }
+
+  return avro_schema;
+}
+
+static void schema_unload_cb_trampoline (serdes_schema_t *schema,
+                                         void *schema_obj, void *opaque) {
+  avro::ValidSchema *avro_schema = static_cast<avro::ValidSchema*>(schema_obj);
+  delete avro_schema;
+}
+
+Serdes::Avro::~Avro () {
+
+}
+
+Avro *Avro::create (const Conf *conf, std::string &errstr) {
+  AvroImpl *avimpl = new AvroImpl();
+
+  if (create_serdes(avimpl, conf, errstr, schema_load_cb_trampoline, schema_unload_cb_trampoline) == -1) {
+    delete avimpl;
+    return NULL;
+  }
+
+  return avimpl;
+}
+
+
+ssize_t AvroImpl::serialize (Schema *schema, const avro::GenericDatum *datum,
+                             std::vector<char> &out, std::string &errstr) {
+  auto avro_schema = schema->object();
+
+  /* Binary encoded output stream */
+  auto bin_os = avro::memoryOutputStream();
+  /* Avro binary encoder */
+  auto bin_encoder = avro::validatingEncoder(*avro_schema, avro::binaryEncoder());
+
+  try {
+    /* Encode Avro datum to Avro binary format */
+    bin_encoder->init(*bin_os.get());
+    avro::encode(*bin_encoder, *datum);
+    bin_encoder->flush();
+
+  } catch (const avro::Exception &e) {
+    errstr = std::string("Avro serialization failed: ") + e.what();
+    return -1;
+  }
+
+  /* Extract written bytes. */
+  auto encoded = avro::snapshot(*bin_os.get());
+
+  /* Write framing */
+  schema->framing_write(out);
+
+  /* Write binary encoded Avro to output vector */
+  out.insert(out.end(), encoded->cbegin(), encoded->cend());
+
+  return out.size();
+}
+
+
+ssize_t AvroImpl::deserialize (Schema **schemap, avro::GenericDatum **datump,
+                               const void *payload, size_t size,
+                               std::string &errstr) {
+  serdes_schema_t *ss;
+
+  /* Read framing */
+  char c_errstr[256];
+  ssize_t r = serdes_framing_read(sd_, &payload, &size, &ss,
+                                  c_errstr, sizeof(c_errstr));
+  if (r == -1) {
+    errstr = c_errstr;
+    return -1;
+  } else if (r == 0 && !*schemap) {
+    errstr = "Unable to decode payload: No framing and no schema specified";
+    return -1;
+  }
+
+  Schema *schema = *schemap;
+  if (!schema) {
+    schema = Serdes::Schema::get(dynamic_cast<HandleImpl*>(this),
+                                 serdes_schema_id(ss), errstr);
+    if (!schema)
+      return -1;
+  }
+
+  avro::ValidSchema *avro_schema = schema->object();
+
+  /* Binary input stream */
+  auto bin_is = avro::memoryInputStream((const uint8_t *)payload, size);
+
+  /* Binary Avro decoder */
+  avro::DecoderPtr bin_decoder = avro::validatingDecoder(*avro_schema,
+                                                         avro::binaryDecoder());
+
+  avro::GenericDatum *datum = new avro::GenericDatum(*avro_schema);
+
+  try {
+    /* Decode binary to Avro datum */
+    bin_decoder->init(*bin_is);
+    avro::decode(*bin_decoder, *datum);
+
+  } catch (const avro::Exception &e) {
+    errstr = std::string("Avro deserialization failed: ") + e.what();
+    delete datum;
+    return -1;
+  }
+
+  *schemap = schema;
+  *datump = datum;
+  return 0;
+}
+
+}
+

--- a/src-cpp/serdescpp-avro.h
+++ b/src-cpp/serdescpp-avro.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src-cpp/serdescpp-avro_int.h
+++ b/src-cpp/serdescpp-avro_int.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src-cpp/serdescpp-avro_int.h
+++ b/src-cpp/serdescpp-avro_int.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+/**
+ * Internal Avro implementation of libserdes C++ interface
+ */
+
+#include "serdescpp_int.h"
+#include "serdescpp-avro.h"
+
+namespace Serdes {
+
+
+  class AvroImpl : public Avro, public HandleImpl {
+ public:
+    ~AvroImpl () { }
+
+    static Avro *create (const Conf *conf, std::string &errstr);
+
+    ssize_t serialize (Schema *schema, const avro::GenericDatum *datum,
+                       std::vector<char> &out, std::string &errstr);
+
+    ssize_t deserialize (Schema **schemap, avro::GenericDatum **datump,
+                         const void *payload, size_t size, std::string &errstr);
+
+    ssize_t serializer_framing_size () const {
+      return HandleImpl::serializer_framing_size();
+    }
+
+    ssize_t deserializer_framing_size () const {
+      return HandleImpl::deserializer_framing_size();
+    }
+
+    int schemas_purge (int max_age) {
+      return HandleImpl::schemas_purge(max_age);
+    }
+
+  };
+
+}

--- a/src-cpp/serdescpp.h
+++ b/src-cpp/serdescpp.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src-cpp/serdescpp.h
+++ b/src-cpp/serdescpp.h
@@ -16,8 +16,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
-#include <avro/ValidSchema.hh>
+// forward declaration
+namespace avro {
+    class ValidSchema;
+}
 
 
 /**

--- a/src-cpp/serdescpp_int.h
+++ b/src-cpp/serdescpp_int.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src-cpp/serdescpp_int.h
+++ b/src-cpp/serdescpp_int.h
@@ -25,10 +25,26 @@ extern "C" {
 #include "serdes.h"
 };
 
+#include "serdescpp.h"
 
 namespace Serdes {
 
+  typedef void* (*schema_load_cb_t) (
+      serdes_schema_t* schema,
+      const char* definition,
+      size_t definition_len,
+      char* errstr,
+      size_t errstr_size,
+      void* opaque
+  );
 
+  typedef void (*schema_unload_cb_t) (
+      serdes_schema_t* schema,
+      void* schema_obj,
+      void* opaque
+  );
+
+    inline
   std::string err2str (ErrorCode err) {
     return std::string(serdes_err2str(static_cast<serdes_err_t>(err)));
   }
@@ -76,8 +92,6 @@ namespace Serdes {
       if (sd_)
         serdes_destroy(sd_);
     }
-
-    static Handle *create (const Conf *conf, std::string &errstr);
 
     HandleImpl (): log_cb_(NULL), sd_(NULL) {}
 
@@ -158,31 +172,9 @@ namespace Serdes {
     serdes_schema_t *schema_;
   };
 
-
-  class AvroImpl : public Avro, public HandleImpl {
- public:
-    ~AvroImpl () { }
-
-    static Avro *create (const Conf *conf, std::string &errstr);
-
-    ssize_t serialize (Schema *schema, const avro::GenericDatum *datum,
-                       std::vector<char> &out, std::string &errstr);
-
-    ssize_t deserialize (Schema **schemap, avro::GenericDatum **datump,
-                         const void *payload, size_t size, std::string &errstr);
-
-    ssize_t serializer_framing_size () const {
-      return HandleImpl::serializer_framing_size();
-    }
-
-    ssize_t deserializer_framing_size () const {
-      return HandleImpl::deserializer_framing_size();
-    }
-
-    int schemas_purge (int max_age) {
-      return HandleImpl::schemas_purge(max_age);
-    }
-
-  };
+  /**
+   * Common function to create a serdes handle based on conf.
+   */
+  int create_serdes(HandleImpl* hnd, const Conf* conf, std::string& errstr, schema_load_cb_t load_cb, schema_unload_cb_t unload_cb);
 
 }

--- a/src/framing.c
+++ b/src/framing.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/framing.c
+++ b/src/framing.c
@@ -16,8 +16,13 @@
 
 #include "serdes_int.h"
 
+#include <stdint.h>
+#include <stdio.h>
+#ifdef _WIN32
+#include <winsock.h>
+#else
 #include <arpa/inet.h> /* ntohl/htonl */
-
+#endif
 
 size_t serdes_serializer_framing_size (serdes_t *sd) {
         switch (sd->sd_conf.serializer_framing)

--- a/src/rest.c
+++ b/src/rest.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/rest.c
+++ b/src/rest.c
@@ -18,6 +18,10 @@
 #include <stdarg.h>
 #include <assert.h>
 
+#ifdef _MSC_VER
+  #include <malloc.h>
+#endif
+
 #include <curl/curl.h>
 
 #include "rest.h"
@@ -358,7 +362,7 @@ static CURLcode rest_req_curl (CURL *curl, rest_response_t *rr) {
  *
  * Returns a response handle which needs to be checked for error.
  */
-static rest_response_t *rest_req (url_list_t *ul, rest_cmd_t cmd,
+static rest_response_t * rest_req(url_list_t * ul, rest_cmd_t cmd,
                                   const void *payload, int size,
                                   const char *url_path_fmt, va_list ap) {
 
@@ -388,8 +392,8 @@ static rest_response_t *rest_req (url_list_t *ul, rest_cmd_t cmd,
         /* Response holder */
         rr = rest_response_new(0);
 
-#define do_curl_setopt(curl,opt,val...) do {                            \
-                CURLcode _ccode = curl_easy_setopt(curl, opt, val);     \
+#define do_curl_setopt(curl,opt,...) do {                            \
+                CURLcode _ccode = curl_easy_setopt(curl, opt, __VA_ARGS__);     \
                 if (_ccode != CURLE_OK) {                               \
                         rest_response_set_result(rr, -1,                \
                                                  "curl: setopt %s failed: %s", \

--- a/src/rest.h
+++ b/src/rest.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/schema-cache.c
+++ b/src/schema-cache.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/serdes-common.h
+++ b/src/serdes-common.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/serdes-common.h
+++ b/src/serdes-common.h
@@ -15,6 +15,12 @@
  */
 #pragma once
 
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
+#include <unistd.h>
+#endif
 
 /*******************************************************************************
  *
@@ -39,7 +45,7 @@ typedef enum {
 } serdes_err_t;
 
 
-#ifdef _MSC_VER
+#if defined _MSC_VER && defined SERDES_USE_DLL
 /* MSVC Win32 DLL symbol exports */
 #undef SERDES_EXPORT
 #ifdef SERDES_DLL_EXPORTS /* Set when building DLL */

--- a/src/serdes.c
+++ b/src/serdes.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/serdes.c
+++ b/src/serdes.c
@@ -17,6 +17,8 @@
 #include "serdes_int.h"
 
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 const char *serdes_err2str (serdes_err_t err) {
         switch (err)

--- a/src/serdes.h
+++ b/src/serdes.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/serdes.h
+++ b/src/serdes.h
@@ -23,7 +23,6 @@
  */
 #include "serdes-common.h"
 
-
 /* Private types, all access through methods */
 typedef struct serdes_s serdes_t;
 typedef struct serdes_schema_s serdes_schema_t;

--- a/src/serdes_int.h
+++ b/src/serdes_int.h
@@ -16,10 +16,16 @@
 #pragma once
 
 #include <sys/queue.h>
-
+#if ENABLE_AVRO_C
 #include <avro.h>
+#endif
 
-#include "../config.h"
+#include <string.h>
+
+#ifndef HAVE_NO_CONFIG
+  #include "../config.h"
+#endif
+
 #include "tinycthread.h"
 #include "serdes.h"
 #include "rest.h"
@@ -37,9 +43,9 @@
 #endif
 
 /* Conditional Debugging macro */
-#define DBG(SD,FAC,FMT...) do {                                 \
-                if ((SD)->sd_conf.debug)                        \
-                        serdes_log(SD, LOG_DEBUG, FAC, FMT);    \
+#define DBG(SD,FAC,...) do {                                                          \
+                if ((SD)->sd_conf.debug)                                              \
+                        serdes_log(SD, LOG_DEBUG, FAC, __VA_ARGS__);    \
         } while (0)
 
 

--- a/src/serdes_int.h
+++ b/src/serdes_int.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2015-2023 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/tinycthread.c
+++ b/src/tinycthread.c
@@ -53,7 +53,7 @@ freely, subject to the following restrictions:
 extern "C" {
 #endif
 
-#define __TLS __thread
+#define __TLS _Thread_local
 static __TLS int thrd_is_detached;
 
 

--- a/windows/include/sys/_null.h
+++ b/windows/include/sys/_null.h
@@ -1,0 +1,18 @@
+/*	$OpenBSD: _null.h,v 1.2 2016/09/09 22:07:58 millert Exp $	*/
+
+/*
+ * Written by Todd C. Miller, September 9, 2016
+ * Public domain.
+ */
+
+#ifndef NULL
+#if !defined(__cplusplus)
+#define	NULL	((void *)0)
+#elif __cplusplus >= 201103L
+#define	NULL	nullptr
+#elif defined(__GNUG__)
+#define	NULL	__null
+#else
+#define	NULL	0L
+#endif
+#endif

--- a/windows/include/sys/queue.h
+++ b/windows/include/sys/queue.h
@@ -1,0 +1,633 @@
+/*	$OpenBSD: queue.h,v 1.46 2020/12/30 13:33:12 millert Exp $	*/
+/*	$NetBSD: queue.h,v 1.11 1996/05/16 05:17:14 mycroft Exp $	*/
+
+/*
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)queue.h	8.5 (Berkeley) 8/20/94
+ */
+
+#ifndef	_SYS_QUEUE_H_
+#define	_SYS_QUEUE_H_
+
+#include <sys/_null.h>
+
+/*
+ * This file defines five types of data structures: singly-linked lists,
+ * lists, simple queues, tail queues and XOR simple queues.
+ *
+ *
+ * A singly-linked list is headed by a single forward pointer. The elements
+ * are singly linked for minimum space and pointer manipulation overhead at
+ * the expense of O(n) removal for arbitrary elements. New elements can be
+ * added to the list after an existing element or at the head of the list.
+ * Elements being removed from the head of the list should use the explicit
+ * macro for this purpose for optimum efficiency. A singly-linked list may
+ * only be traversed in the forward direction.  Singly-linked lists are ideal
+ * for applications with large datasets and few or no removals or for
+ * implementing a LIFO queue.
+ *
+ * A list is headed by a single forward pointer (or an array of forward
+ * pointers for a hash table header). The elements are doubly linked
+ * so that an arbitrary element can be removed without a need to
+ * traverse the list. New elements can be added to the list before
+ * or after an existing element or at the head of the list. A list
+ * may only be traversed in the forward direction.
+ *
+ * A simple queue is headed by a pair of pointers, one to the head of the
+ * list and the other to the tail of the list. The elements are singly
+ * linked to save space, so elements can only be removed from the
+ * head of the list. New elements can be added to the list before or after
+ * an existing element, at the head of the list, or at the end of the
+ * list. A simple queue may only be traversed in the forward direction.
+ *
+ * A tail queue is headed by a pair of pointers, one to the head of the
+ * list and the other to the tail of the list. The elements are doubly
+ * linked so that an arbitrary element can be removed without a need to
+ * traverse the list. New elements can be added to the list before or
+ * after an existing element, at the head of the list, or at the end of
+ * the list. A tail queue may be traversed in either direction.
+ *
+ * An XOR simple queue is used in the same way as a regular simple queue.
+ * The difference is that the head structure also includes a "cookie" that
+ * is XOR'd with the queue pointer (first, last or next) to generate the
+ * real pointer value.
+ *
+ * For details on the use of these macros, see the queue(3) manual page.
+ */
+
+#if defined(QUEUE_MACRO_DEBUG) || (defined(_KERNEL) && defined(DIAGNOSTIC))
+#define _Q_INVALID ((void *)-1)
+#define _Q_INVALIDATE(a) (a) = _Q_INVALID
+#else
+#define _Q_INVALIDATE(a)
+#endif
+
+/*
+ * Singly-linked List definitions.
+ */
+#define SLIST_HEAD(name, type)						\
+struct name {								\
+	struct type *slh_first;	/* first element */			\
+}
+
+#define	SLIST_HEAD_INITIALIZER(head)					\
+	{ NULL }
+
+#define SLIST_ENTRY(type)						\
+struct {								\
+	struct type *sle_next;	/* next element */			\
+}
+
+/*
+ * Singly-linked List access methods.
+ */
+#define	SLIST_FIRST(head)	((head)->slh_first)
+#define	SLIST_END(head)		NULL
+#define	SLIST_EMPTY(head)	(SLIST_FIRST(head) == SLIST_END(head))
+#define	SLIST_NEXT(elm, field)	((elm)->field.sle_next)
+
+#define	SLIST_FOREACH(var, head, field)					\
+	for((var) = SLIST_FIRST(head);					\
+	    (var) != SLIST_END(head);					\
+	    (var) = SLIST_NEXT(var, field))
+
+#define	SLIST_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = SLIST_FIRST(head);				\
+	    (var) && ((tvar) = SLIST_NEXT(var, field), 1);		\
+	    (var) = (tvar))
+
+/*
+ * Singly-linked List functions.
+ */
+#define	SLIST_INIT(head) {						\
+	SLIST_FIRST(head) = SLIST_END(head);				\
+}
+
+#define	SLIST_INSERT_AFTER(slistelm, elm, field) do {			\
+	(elm)->field.sle_next = (slistelm)->field.sle_next;		\
+	(slistelm)->field.sle_next = (elm);				\
+} while (0)
+
+#define	SLIST_INSERT_HEAD(head, elm, field) do {			\
+	(elm)->field.sle_next = (head)->slh_first;			\
+	(head)->slh_first = (elm);					\
+} while (0)
+
+#define	SLIST_REMOVE_AFTER(elm, field) do {				\
+	(elm)->field.sle_next = (elm)->field.sle_next->field.sle_next;	\
+} while (0)
+
+#define	SLIST_REMOVE_HEAD(head, field) do {				\
+	(head)->slh_first = (head)->slh_first->field.sle_next;		\
+} while (0)
+
+#define SLIST_REMOVE(head, elm, type, field) do {			\
+	if ((head)->slh_first == (elm)) {				\
+		SLIST_REMOVE_HEAD((head), field);			\
+	} else {							\
+		struct type *curelm = (head)->slh_first;		\
+									\
+		while (curelm->field.sle_next != (elm))			\
+			curelm = curelm->field.sle_next;		\
+		curelm->field.sle_next =				\
+		    curelm->field.sle_next->field.sle_next;		\
+	}								\
+	_Q_INVALIDATE((elm)->field.sle_next);				\
+} while (0)
+
+/*
+ * List definitions.
+ */
+#define LIST_HEAD(name, type)						\
+struct name {								\
+	struct type *lh_first;	/* first element */			\
+}
+
+#define LIST_HEAD_INITIALIZER(head)					\
+	{ NULL }
+
+#define LIST_ENTRY(type)						\
+struct {								\
+	struct type *le_next;	/* next element */			\
+	struct type **le_prev;	/* address of previous next element */	\
+}
+
+/*
+ * List access methods.
+ */
+#define	LIST_FIRST(head)		((head)->lh_first)
+#define	LIST_END(head)			NULL
+#define	LIST_EMPTY(head)		(LIST_FIRST(head) == LIST_END(head))
+#define	LIST_NEXT(elm, field)		((elm)->field.le_next)
+
+#define LIST_FOREACH(var, head, field)					\
+	for((var) = LIST_FIRST(head);					\
+	    (var)!= LIST_END(head);					\
+	    (var) = LIST_NEXT(var, field))
+
+#define	LIST_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = LIST_FIRST(head);				\
+	    (var) && ((tvar) = LIST_NEXT(var, field), 1);		\
+	    (var) = (tvar))
+
+/*
+ * List functions.
+ */
+#define	LIST_INIT(head) do {						\
+	LIST_FIRST(head) = LIST_END(head);				\
+} while (0)
+
+#define LIST_INSERT_AFTER(listelm, elm, field) do {			\
+	if (((elm)->field.le_next = (listelm)->field.le_next) != NULL)	\
+		(listelm)->field.le_next->field.le_prev =		\
+		    &(elm)->field.le_next;				\
+	(listelm)->field.le_next = (elm);				\
+	(elm)->field.le_prev = &(listelm)->field.le_next;		\
+} while (0)
+
+#define	LIST_INSERT_BEFORE(listelm, elm, field) do {			\
+	(elm)->field.le_prev = (listelm)->field.le_prev;		\
+	(elm)->field.le_next = (listelm);				\
+	*(listelm)->field.le_prev = (elm);				\
+	(listelm)->field.le_prev = &(elm)->field.le_next;		\
+} while (0)
+
+#define LIST_INSERT_HEAD(head, elm, field) do {				\
+	if (((elm)->field.le_next = (head)->lh_first) != NULL)		\
+		(head)->lh_first->field.le_prev = &(elm)->field.le_next;\
+	(head)->lh_first = (elm);					\
+	(elm)->field.le_prev = &(head)->lh_first;			\
+} while (0)
+
+#define LIST_REMOVE(elm, field) do {					\
+	if ((elm)->field.le_next != NULL)				\
+		(elm)->field.le_next->field.le_prev =			\
+		    (elm)->field.le_prev;				\
+	*(elm)->field.le_prev = (elm)->field.le_next;			\
+	_Q_INVALIDATE((elm)->field.le_prev);				\
+	_Q_INVALIDATE((elm)->field.le_next);				\
+} while (0)
+
+#define LIST_REPLACE(elm, elm2, field) do {				\
+	if (((elm2)->field.le_next = (elm)->field.le_next) != NULL)	\
+		(elm2)->field.le_next->field.le_prev =			\
+		    &(elm2)->field.le_next;				\
+	(elm2)->field.le_prev = (elm)->field.le_prev;			\
+	*(elm2)->field.le_prev = (elm2);				\
+	_Q_INVALIDATE((elm)->field.le_prev);				\
+	_Q_INVALIDATE((elm)->field.le_next);				\
+} while (0)
+
+/*
+ * Simple queue definitions.
+ */
+#define SIMPLEQ_HEAD(name, type)					\
+struct name {								\
+	struct type *sqh_first;	/* first element */			\
+	struct type **sqh_last;	/* addr of last next element */		\
+}
+
+#define SIMPLEQ_HEAD_INITIALIZER(head)					\
+	{ NULL, &(head).sqh_first }
+
+#define SIMPLEQ_ENTRY(type)						\
+struct {								\
+	struct type *sqe_next;	/* next element */			\
+}
+
+/*
+ * Simple queue access methods.
+ */
+#define	SIMPLEQ_FIRST(head)	    ((head)->sqh_first)
+#define	SIMPLEQ_END(head)	    NULL
+#define	SIMPLEQ_EMPTY(head)	    (SIMPLEQ_FIRST(head) == SIMPLEQ_END(head))
+#define	SIMPLEQ_NEXT(elm, field)    ((elm)->field.sqe_next)
+
+#define SIMPLEQ_FOREACH(var, head, field)				\
+	for((var) = SIMPLEQ_FIRST(head);				\
+	    (var) != SIMPLEQ_END(head);					\
+	    (var) = SIMPLEQ_NEXT(var, field))
+
+#define	SIMPLEQ_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = SIMPLEQ_FIRST(head);				\
+	    (var) && ((tvar) = SIMPLEQ_NEXT(var, field), 1);		\
+	    (var) = (tvar))
+
+/*
+ * Simple queue functions.
+ */
+#define	SIMPLEQ_INIT(head) do {						\
+	(head)->sqh_first = NULL;					\
+	(head)->sqh_last = &(head)->sqh_first;				\
+} while (0)
+
+#define SIMPLEQ_INSERT_HEAD(head, elm, field) do {			\
+	if (((elm)->field.sqe_next = (head)->sqh_first) == NULL)	\
+		(head)->sqh_last = &(elm)->field.sqe_next;		\
+	(head)->sqh_first = (elm);					\
+} while (0)
+
+#define SIMPLEQ_INSERT_TAIL(head, elm, field) do {			\
+	(elm)->field.sqe_next = NULL;					\
+	*(head)->sqh_last = (elm);					\
+	(head)->sqh_last = &(elm)->field.sqe_next;			\
+} while (0)
+
+#define SIMPLEQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	if (((elm)->field.sqe_next = (listelm)->field.sqe_next) == NULL)\
+		(head)->sqh_last = &(elm)->field.sqe_next;		\
+	(listelm)->field.sqe_next = (elm);				\
+} while (0)
+
+#define SIMPLEQ_REMOVE_HEAD(head, field) do {			\
+	if (((head)->sqh_first = (head)->sqh_first->field.sqe_next) == NULL) \
+		(head)->sqh_last = &(head)->sqh_first;			\
+} while (0)
+
+#define SIMPLEQ_REMOVE_AFTER(head, elm, field) do {			\
+	if (((elm)->field.sqe_next = (elm)->field.sqe_next->field.sqe_next) \
+	    == NULL)							\
+		(head)->sqh_last = &(elm)->field.sqe_next;		\
+} while (0)
+
+#define SIMPLEQ_CONCAT(head1, head2) do {				\
+	if (!SIMPLEQ_EMPTY((head2))) {					\
+		*(head1)->sqh_last = (head2)->sqh_first;		\
+		(head1)->sqh_last = (head2)->sqh_last;			\
+		SIMPLEQ_INIT((head2));					\
+	}								\
+} while (0)
+
+/*
+ * XOR Simple queue definitions.
+ */
+#define XSIMPLEQ_HEAD(name, type)					\
+struct name {								\
+	struct type *sqx_first;	/* first element */			\
+	struct type **sqx_last;	/* addr of last next element */		\
+	unsigned long sqx_cookie;					\
+}
+
+#define XSIMPLEQ_ENTRY(type)						\
+struct {								\
+	struct type *sqx_next;	/* next element */			\
+}
+
+/*
+ * XOR Simple queue access methods.
+ */
+#define XSIMPLEQ_XOR(head, ptr)	    ((__typeof(ptr))((head)->sqx_cookie ^ \
+					(unsigned long)(ptr)))
+#define	XSIMPLEQ_FIRST(head)	    XSIMPLEQ_XOR(head, ((head)->sqx_first))
+#define	XSIMPLEQ_END(head)	    NULL
+#define	XSIMPLEQ_EMPTY(head)	    (XSIMPLEQ_FIRST(head) == XSIMPLEQ_END(head))
+#define	XSIMPLEQ_NEXT(head, elm, field)    XSIMPLEQ_XOR(head, ((elm)->field.sqx_next))
+
+
+#define XSIMPLEQ_FOREACH(var, head, field)				\
+	for ((var) = XSIMPLEQ_FIRST(head);				\
+	    (var) != XSIMPLEQ_END(head);				\
+	    (var) = XSIMPLEQ_NEXT(head, var, field))
+
+#define	XSIMPLEQ_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = XSIMPLEQ_FIRST(head);				\
+	    (var) && ((tvar) = XSIMPLEQ_NEXT(head, var, field), 1);	\
+	    (var) = (tvar))
+
+/*
+ * XOR Simple queue functions.
+ */
+#define	XSIMPLEQ_INIT(head) do {					\
+	arc4random_buf(&(head)->sqx_cookie, sizeof((head)->sqx_cookie)); \
+	(head)->sqx_first = XSIMPLEQ_XOR(head, NULL);			\
+	(head)->sqx_last = XSIMPLEQ_XOR(head, &(head)->sqx_first);	\
+} while (0)
+
+#define XSIMPLEQ_INSERT_HEAD(head, elm, field) do {			\
+	if (((elm)->field.sqx_next = (head)->sqx_first) ==		\
+	    XSIMPLEQ_XOR(head, NULL))					\
+		(head)->sqx_last = XSIMPLEQ_XOR(head, &(elm)->field.sqx_next); \
+	(head)->sqx_first = XSIMPLEQ_XOR(head, (elm));			\
+} while (0)
+
+#define XSIMPLEQ_INSERT_TAIL(head, elm, field) do {			\
+	(elm)->field.sqx_next = XSIMPLEQ_XOR(head, NULL);		\
+	*(XSIMPLEQ_XOR(head, (head)->sqx_last)) = XSIMPLEQ_XOR(head, (elm)); \
+	(head)->sqx_last = XSIMPLEQ_XOR(head, &(elm)->field.sqx_next);	\
+} while (0)
+
+#define XSIMPLEQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	if (((elm)->field.sqx_next = (listelm)->field.sqx_next) ==	\
+	    XSIMPLEQ_XOR(head, NULL))					\
+		(head)->sqx_last = XSIMPLEQ_XOR(head, &(elm)->field.sqx_next); \
+	(listelm)->field.sqx_next = XSIMPLEQ_XOR(head, (elm));		\
+} while (0)
+
+#define XSIMPLEQ_REMOVE_HEAD(head, field) do {				\
+	if (((head)->sqx_first = XSIMPLEQ_XOR(head,			\
+	    (head)->sqx_first)->field.sqx_next) == XSIMPLEQ_XOR(head, NULL)) \
+		(head)->sqx_last = XSIMPLEQ_XOR(head, &(head)->sqx_first); \
+} while (0)
+
+#define XSIMPLEQ_REMOVE_AFTER(head, elm, field) do {			\
+	if (((elm)->field.sqx_next = XSIMPLEQ_XOR(head,			\
+	    (elm)->field.sqx_next)->field.sqx_next)			\
+	    == XSIMPLEQ_XOR(head, NULL))				\
+		(head)->sqx_last = 					\
+		    XSIMPLEQ_XOR(head, &(elm)->field.sqx_next);		\
+} while (0)
+
+
+/*
+ * Tail queue definitions.
+ */
+#define TAILQ_HEAD(name, type)						\
+struct name {								\
+	struct type *tqh_first;	/* first element */			\
+	struct type **tqh_last;	/* addr of last next element */		\
+}
+
+#define TAILQ_HEAD_INITIALIZER(head)					\
+	{ NULL, &(head).tqh_first }
+
+#define TAILQ_ENTRY(type)						\
+struct {								\
+	struct type *tqe_next;	/* next element */			\
+	struct type **tqe_prev;	/* address of previous next element */	\
+}
+
+/*
+ * Tail queue access methods.
+ */
+#define	TAILQ_FIRST(head)		((head)->tqh_first)
+#define	TAILQ_END(head)			NULL
+#define	TAILQ_NEXT(elm, field)		((elm)->field.tqe_next)
+#define TAILQ_LAST(head, headname)					\
+	(*(((struct headname *)((head)->tqh_last))->tqh_last))
+/* XXX */
+#define TAILQ_PREV(elm, headname, field)				\
+	(*(((struct headname *)((elm)->field.tqe_prev))->tqh_last))
+#define	TAILQ_EMPTY(head)						\
+	(TAILQ_FIRST(head) == TAILQ_END(head))
+
+#define TAILQ_FOREACH(var, head, field)					\
+	for((var) = TAILQ_FIRST(head);					\
+	    (var) != TAILQ_END(head);					\
+	    (var) = TAILQ_NEXT(var, field))
+
+#define	TAILQ_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = TAILQ_FIRST(head);					\
+	    (var) != TAILQ_END(head) &&					\
+	    ((tvar) = TAILQ_NEXT(var, field), 1);			\
+	    (var) = (tvar))
+
+
+#define TAILQ_FOREACH_REVERSE(var, head, headname, field)		\
+	for((var) = TAILQ_LAST(head, headname);				\
+	    (var) != TAILQ_END(head);					\
+	    (var) = TAILQ_PREV(var, headname, field))
+
+#define	TAILQ_FOREACH_REVERSE_SAFE(var, head, headname, field, tvar)	\
+	for ((var) = TAILQ_LAST(head, headname);			\
+	    (var) != TAILQ_END(head) &&					\
+	    ((tvar) = TAILQ_PREV(var, headname, field), 1);		\
+	    (var) = (tvar))
+
+/*
+ * Tail queue functions.
+ */
+#define	TAILQ_INIT(head) do {						\
+	(head)->tqh_first = NULL;					\
+	(head)->tqh_last = &(head)->tqh_first;				\
+} while (0)
+
+#define TAILQ_INSERT_HEAD(head, elm, field) do {			\
+	if (((elm)->field.tqe_next = (head)->tqh_first) != NULL)	\
+		(head)->tqh_first->field.tqe_prev =			\
+		    &(elm)->field.tqe_next;				\
+	else								\
+		(head)->tqh_last = &(elm)->field.tqe_next;		\
+	(head)->tqh_first = (elm);					\
+	(elm)->field.tqe_prev = &(head)->tqh_first;			\
+} while (0)
+
+#define TAILQ_INSERT_TAIL(head, elm, field) do {			\
+	(elm)->field.tqe_next = NULL;					\
+	(elm)->field.tqe_prev = (head)->tqh_last;			\
+	*(head)->tqh_last = (elm);					\
+	(head)->tqh_last = &(elm)->field.tqe_next;			\
+} while (0)
+
+#define TAILQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	if (((elm)->field.tqe_next = (listelm)->field.tqe_next) != NULL)\
+		(elm)->field.tqe_next->field.tqe_prev =			\
+		    &(elm)->field.tqe_next;				\
+	else								\
+		(head)->tqh_last = &(elm)->field.tqe_next;		\
+	(listelm)->field.tqe_next = (elm);				\
+	(elm)->field.tqe_prev = &(listelm)->field.tqe_next;		\
+} while (0)
+
+#define	TAILQ_INSERT_BEFORE(listelm, elm, field) do {			\
+	(elm)->field.tqe_prev = (listelm)->field.tqe_prev;		\
+	(elm)->field.tqe_next = (listelm);				\
+	*(listelm)->field.tqe_prev = (elm);				\
+	(listelm)->field.tqe_prev = &(elm)->field.tqe_next;		\
+} while (0)
+
+#define TAILQ_REMOVE(head, elm, field) do {				\
+	if (((elm)->field.tqe_next) != NULL)				\
+		(elm)->field.tqe_next->field.tqe_prev =			\
+		    (elm)->field.tqe_prev;				\
+	else								\
+		(head)->tqh_last = (elm)->field.tqe_prev;		\
+	*(elm)->field.tqe_prev = (elm)->field.tqe_next;			\
+	_Q_INVALIDATE((elm)->field.tqe_prev);				\
+	_Q_INVALIDATE((elm)->field.tqe_next);				\
+} while (0)
+
+#define TAILQ_REPLACE(head, elm, elm2, field) do {			\
+	if (((elm2)->field.tqe_next = (elm)->field.tqe_next) != NULL)	\
+		(elm2)->field.tqe_next->field.tqe_prev =		\
+		    &(elm2)->field.tqe_next;				\
+	else								\
+		(head)->tqh_last = &(elm2)->field.tqe_next;		\
+	(elm2)->field.tqe_prev = (elm)->field.tqe_prev;			\
+	*(elm2)->field.tqe_prev = (elm2);				\
+	_Q_INVALIDATE((elm)->field.tqe_prev);				\
+	_Q_INVALIDATE((elm)->field.tqe_next);				\
+} while (0)
+
+#define TAILQ_CONCAT(head1, head2, field) do {				\
+	if (!TAILQ_EMPTY(head2)) {					\
+		*(head1)->tqh_last = (head2)->tqh_first;		\
+		(head2)->tqh_first->field.tqe_prev = (head1)->tqh_last;	\
+		(head1)->tqh_last = (head2)->tqh_last;			\
+		TAILQ_INIT((head2));					\
+	}								\
+} while (0)
+
+/*
+ * Singly-linked Tail queue declarations.
+ */
+#define	STAILQ_HEAD(name, type)						\
+struct name {								\
+	struct type *stqh_first;	/* first element */		\
+	struct type **stqh_last;	/* addr of last next element */	\
+}
+
+#define	STAILQ_HEAD_INITIALIZER(head)					\
+	{ NULL, &(head).stqh_first }
+
+#define	STAILQ_ENTRY(type)						\
+struct {								\
+	struct type *stqe_next;	/* next element */			\
+}
+
+/*
+ * Singly-linked Tail queue access methods.
+ */
+#define	STAILQ_FIRST(head)	((head)->stqh_first)
+#define	STAILQ_END(head)	NULL
+#define	STAILQ_EMPTY(head)	(STAILQ_FIRST(head) == STAILQ_END(head))
+#define	STAILQ_NEXT(elm, field)	((elm)->field.stqe_next)
+
+#define STAILQ_FOREACH(var, head, field)				\
+	for ((var) = STAILQ_FIRST(head);				\
+	    (var) != STAILQ_END(head);					\
+	    (var) = STAILQ_NEXT(var, field))
+
+#define	STAILQ_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = STAILQ_FIRST(head);				\
+	    (var) && ((tvar) = STAILQ_NEXT(var, field), 1);		\
+	    (var) = (tvar))
+
+/*
+ * Singly-linked Tail queue functions.
+ */
+#define	STAILQ_INIT(head) do {						\
+	STAILQ_FIRST((head)) = NULL;					\
+	(head)->stqh_last = &STAILQ_FIRST((head));			\
+} while (0)
+
+#define	STAILQ_INSERT_HEAD(head, elm, field) do {			\
+	if ((STAILQ_NEXT((elm), field) = STAILQ_FIRST((head))) == NULL)	\
+		(head)->stqh_last = &STAILQ_NEXT((elm), field);		\
+	STAILQ_FIRST((head)) = (elm);					\
+} while (0)
+
+#define	STAILQ_INSERT_TAIL(head, elm, field) do {			\
+	STAILQ_NEXT((elm), field) = NULL;				\
+	*(head)->stqh_last = (elm);					\
+	(head)->stqh_last = &STAILQ_NEXT((elm), field);			\
+} while (0)
+
+#define	STAILQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	if ((STAILQ_NEXT((elm), field) = STAILQ_NEXT((elm), field)) == NULL)\
+		(head)->stqh_last = &STAILQ_NEXT((elm), field);		\
+	STAILQ_NEXT((elm), field) = (elm);				\
+} while (0)
+
+#define STAILQ_REMOVE_HEAD(head, field) do {                            \
+	if ((STAILQ_FIRST((head)) =					\
+	    STAILQ_NEXT(STAILQ_FIRST((head)), field)) == NULL)		\
+		(head)->stqh_last = &STAILQ_FIRST((head));		\
+} while (0)
+
+#define STAILQ_REMOVE_AFTER(head, elm, field) do {                      \
+	if ((STAILQ_NEXT(elm, field) =					\
+	    STAILQ_NEXT(STAILQ_NEXT(elm, field), field)) == NULL)	\
+		(head)->stqh_last = &STAILQ_NEXT((elm), field);		\
+} while (0)
+
+#define	STAILQ_REMOVE(head, elm, type, field) do {			\
+	if (STAILQ_FIRST((head)) == (elm)) {				\
+		STAILQ_REMOVE_HEAD((head), field);			\
+	} else {							\
+		struct type *curelm = (head)->stqh_first;		\
+		while (STAILQ_NEXT(curelm, field) != (elm))		\
+			curelm = STAILQ_NEXT(curelm, field);		\
+		STAILQ_REMOVE_AFTER(head, curelm, field);		\
+	}								\
+} while (0)
+
+#define	STAILQ_CONCAT(head1, head2) do {				\
+	if (!STAILQ_EMPTY((head2))) {					\
+		*(head1)->stqh_last = (head2)->stqh_first;		\
+		(head1)->stqh_last = (head2)->stqh_last;		\
+		STAILQ_INIT((head2));					\
+	}								\
+} while (0)
+
+#define	STAILQ_LAST(head, type, field)					\
+	(STAILQ_EMPTY((head)) ?	NULL :					\
+	        ((struct type *)(void *)				\
+		((char *)((head)->stqh_last) - offsetof(struct type, field))))
+
+#endif	/* !_SYS_QUEUE_H_ */


### PR DESCRIPTION
This update purpose many improvements:
* add windows support.
* add cmake support to build serdes and serdes++ static libraries. Option build are detailed in Readme.md.
* separate tinycthread build in another static library to avoid multiple definition conflict when libserdes is linked with librdkafka.
* fix memory access violation if custom schema handle is not HandleImpl based.
