### PR TITLE
chore: remove const that has no effect

### DIFF
--- a/src/serdes-avro.h
+++ b/src/serdes-avro.h
@@ -92,5 +92,4 @@ serdes_err_t serdes_deserialize_avro (serdes_t *serdes, avro_value_t *avro,
  * Returns the avro_schema_t object for a schema.
  */
 SERDES_EXPORT
-const avro_schema_t serdes_schema_avro (serdes_schema_t *schema);
-
+avro_schema_t serdes_schema_avro (serdes_schema_t *schema);


### PR DESCRIPTION
Just a small update. When I use `set(CMAKE_C_FLAGS "-Wall -Werror -Wextra")` in CMakeList.txt file, I got error:

```sh
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc  -I/opt/homebrew/opt/avro-c/include -I/opt/homebrew/opt/libserdes/include -isystem /opt/homebrew/Cellar/glib/2.80.4/include/glib-2.0 -isystem /opt/homebrew/Cellar/glib/2.80.4/lib/glib-2.0/include -isystem /opt/homebrew/opt/gettext/include -isystem /opt/homebrew/Cellar/pcre2/10.44/include -isystem /opt/homebrew/Cellar/librdkafka/2.4.0/include -isystem /opt/homebrew/Cellar/openssl@3/3.3.1/include -isystem /opt/homebrew/opt/zstd/include -isystem /opt/homebrew/Cellar/lz4/1.9.4/include -Wall -Wextra -Werror -g -std=gnu2x -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk -mmacosx-version-min=14.3 -fcolor-diagnostics -MD -MT CMakeFiles/main.dir/src/main.c.o -MF CMakeFiles/main.dir/src/main.c.o.d -o CMakeFiles/main.dir/src/main.c.o -c /Users/hongbo-miao/Clouds/Git/archer-data-computing-machine-learning-infrastructure/kafka/kafka-client/avro-producer/src/main.c
In file included from /Users/hongbo-miao/Clouds/Git/archer-data-computing-machine-learning-infrastructure/kafka/kafka-client/avro-producer/src/main.c:4:
/opt/homebrew/opt/libserdes/include/libserdes/serdes-avro.h:95:1: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
const avro_schema_t serdes_schema_avro (serdes_schema_t *schema);
^~~~~~
1 error generated.
```

The workaround way is

```c
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wignored-qualifiers"
#include <libserdes/serdes-avro.h>
#pragma GCC diagnostic pop
```